### PR TITLE
fix GO111MODULE typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ else
 endif
 
 all: build 
-export GO111MODULES=on
+export GO111MODULE=on
 export GOFLAGS=-mod=vendor
 XCHAIN_ROOT := ${PWD}
 export XCHAIN_ROOT


### PR DESCRIPTION
If the name of this environment variable is wrong, the compilation will degenerate to GOPATH mode.