### PR TITLE
Support external wasm vm 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ XuperUnion is the underlying solution for union networks with following highligh
 
 * OS Support: Linux and Mac OS
 * Go 1.12.x or later
-* G++ 4.8.x or later
+* GCC 4.8.x or later
 * Git
 
 ### Build
@@ -134,7 +134,7 @@ XuperUnion is under the [Apache License, Version 2.0](https://github.com/xuperch
 
 * 操作系统：支持Linux以及Mac OS
 * 开发语言：Go 1.12.x及以上
-* 编译器：G++ 4.8.x及以上
+* 编译器：GCC 4.8.x及以上
 * 版本控制工具：Git
 
 ### 构建

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -137,8 +137,9 @@ type XVMConfig struct {
 
 // WasmConfig wasm config
 type WasmConfig struct {
-	Driver string
-	XVM    XVMConfig
+	Driver   string
+	External bool
+	XVM      XVMConfig
 }
 
 // ConsoleConfig is the command config user input

--- a/contract/wasm/vm_manager.go
+++ b/contract/wasm/vm_manager.go
@@ -14,6 +14,8 @@ import (
 	"github.com/xuperchain/xuperunion/contract/wasm/vm"
 	"github.com/xuperchain/xuperunion/crypto/hash"
 
+	"github.com/xuperchain/xuperunion/pluginmgr"
+
 	// import xvm wasm virtual machine
 	"github.com/xuperchain/xuperunion/contract/bridge"
 	_ "github.com/xuperchain/xuperunion/contract/wasm/vm/xvm"
@@ -41,6 +43,18 @@ func New(cfg *config.WasmConfig, basedir string, xbridge *bridge.XBridge, xmodel
 		xbridge:      xbridge,
 		codeProvider: newCodeProvider(xmodel),
 	}
+
+	pluginMgr, err := pluginmgr.GetPluginMgr()
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.External {
+		if _, err = pluginMgr.PluginMgr.CreatePluginInstance("wasm", cfg.Driver); err != nil {
+			return nil, err
+		}
+	}
+
 	return vmm, nil
 }
 


### PR DESCRIPTION
Background:   xuperunion have `xvm` as its built-in wasm VM, and support other wasm VM, called external wasm VM,  like WAVM.

How to add a new wasm VM:  
1. all the imported function in wasm should be implemented by `call_method` and `fetch_reponse`.
2. Implement interface [`InstanceCreator` ](https://github.com/xuperchain/xuperunion/blob/master/contract/wasm/vm/vm.go#L26) and Instance.
3.  Implement the `GetInstance` interface (the signature is `func GetInstance() interface{}`) so the PluginMgr can load it as a wasm VM Instance. 

More details will be found in the wiki.