### PR TITLE
fix tdpos get check result json unmarshall exception

### DIFF
--- a/consensus/tdpos/common.go
+++ b/consensus/tdpos/common.go
@@ -59,7 +59,7 @@ func (tp *TDpos) isProposer(term int64, pos int64, address []byte) bool {
 }
 
 // 查询当前轮的验证者名单
-func (tp *TDpos) getTermProposer(term int64) []*candidateInfo {
+func (tp *TDpos) getTermProposer(term int64) []*CandidateInfo {
 	if term == 1 {
 		return tp.config.initProposer[1]
 	}
@@ -99,7 +99,7 @@ func (tp *TDpos) getTermProposer(term int64) []*candidateInfo {
 			return tp.config.initProposer[1]
 		}
 	}
-	proposers := []*candidateInfo{}
+	proposers := []*CandidateInfo{}
 	err = json.Unmarshal(val, &proposers)
 	if err != nil {
 		tp.log.Error("TDpos Unmarshal vote result error", "term", term, "error", err)
@@ -110,10 +110,10 @@ func (tp *TDpos) getTermProposer(term int64) []*candidateInfo {
 }
 
 // 生成当前轮的验证者名单
-func (tp *TDpos) genTermProposer() ([]*candidateInfo, error) {
+func (tp *TDpos) genTermProposer() ([]*CandidateInfo, error) {
 	//var res []string
 	var termBallotSli termBallotsSlice
-	res := []*candidateInfo{}
+	res := []*CandidateInfo{}
 
 	tp.candidateBallots.Range(func(k, v interface{}) bool {
 		key := k.(string)
@@ -147,7 +147,7 @@ func (tp *TDpos) genTermProposer() ([]*candidateInfo, error) {
 		if err != nil {
 			return nil, err
 		}
-		var canInfo *candidateInfo
+		var canInfo *CandidateInfo
 		err = json.Unmarshal(ciValue, &canInfo)
 		if err != nil {
 			return nil, err
@@ -283,7 +283,7 @@ func (tp *TDpos) inCandidate(candidate string) bool {
 }
 
 // 验证提名候选人合约参数是否合法
-func (tp *TDpos) validateNominateCandidate(desc *contract.TxDesc) (*candidateInfo, string, error) {
+func (tp *TDpos) validateNominateCandidate(desc *contract.TxDesc) (*CandidateInfo, string, error) {
 	utxoTotal := tp.utxoVM.GetTotal()
 	amount, err := calAmount(desc.Tx)
 	if err != nil {
@@ -291,7 +291,7 @@ func (tp *TDpos) validateNominateCandidate(desc *contract.TxDesc) (*candidateInf
 	}
 	// TODO: zq 多来源以后, 这里需要优化一下
 	fromAddr := string(desc.Tx.TxInputs[0].FromAddr)
-	canInfo := &candidateInfo{}
+	canInfo := &CandidateInfo{}
 
 	utxoTotal.Div(utxoTotal, big.NewInt(minNominateProportion))
 	if ok := amount.Cmp(utxoTotal) >= 0; !ok {

--- a/consensus/tdpos/common_test.go
+++ b/consensus/tdpos/common_test.go
@@ -289,17 +289,17 @@ func TestTermProposerBasic(t *testing.T) {
 			proposerNum:       int64(1),
 			blockNum:          int64(20),
 			voteUnitPrice:     big.NewInt(12),
-			initProposer: map[int64][]*candidateInfo{
-				1: []*candidateInfo{
-					&candidateInfo{
+			initProposer: map[int64][]*CandidateInfo{
+				1: []*CandidateInfo{
+					&CandidateInfo{
 						Address:  "Y4TmpfV4pvhYT5W17J7TqHSLo6cqq23x3",
 						PeerAddr: "peerid1",
 					},
-					&candidateInfo{
+					&CandidateInfo{
 						Address:  "RUEMFGDEnLBpnYYggnXukpVfR9Skm59ph",
 						PeerAddr: "peerid2",
 					},
-					&candidateInfo{
+					&CandidateInfo{
 						Address:  "bob",
 						PeerAddr: "peerid3",
 					},
@@ -309,7 +309,7 @@ func TestTermProposerBasic(t *testing.T) {
 	}
 	tdpos.context = &contract.TxContext{}
 	tdpos.context.UtxoBatch = tdpos.utxoVM.NewBatch()
-	canInfo := &candidateInfo{
+	canInfo := &CandidateInfo{
 		Address:  "f3prTg9itaZY6m48wXXikXdcxiByW7zgk",
 		PeerAddr: "peerid4",
 	}

--- a/consensus/tdpos/run.go
+++ b/consensus/tdpos/run.go
@@ -309,7 +309,7 @@ func (tp *TDpos) runCheckValidater(desc *contract.TxDesc, block *pb.InternalBloc
 }
 
 // triggerProposerChanged triggers a ProposerChanged event
-func (tp *TDpos) triggerProposerChanged(proposers []*candidateInfo) {
+func (tp *TDpos) triggerProposerChanged(proposers []*CandidateInfo) {
 	em := &events.EventMessage{
 		BcName:   tp.bcname,
 		Type:     events.ProposerChanged,

--- a/consensus/tdpos/tdpos.go
+++ b/consensus/tdpos/tdpos.go
@@ -32,7 +32,7 @@ import (
 // Init init tdpos
 func (tp *TDpos) Init() {
 	tp.config = tDposConfig{
-		initProposer: make(map[int64][]*candidateInfo),
+		initProposer: make(map[int64][]*CandidateInfo),
 	}
 	tp.isProduce = make(map[int64]bool)
 	tp.candidateBallots = new(sync.Map)
@@ -232,7 +232,7 @@ func (tp *TDpos) buildConfigs(xlog log.Logger, cfg *config.NodeConfig, consCfg m
 	}
 
 	for _, v := range initProposer1 {
-		canInfo := &candidateInfo{}
+		canInfo := &CandidateInfo{}
 		proposer := v.(map[string]interface{})
 		if _, ok := proposer["address"]; !ok {
 			return errors.New("TDPos init failed, proposer should have address")

--- a/consensus/tdpos/tdpos_test.go
+++ b/consensus/tdpos/tdpos_test.go
@@ -64,21 +64,21 @@ func TestTDpos(t *testing.T) {
 	}
 	tdpos := &TDpos{}
 	tdpos.Init()
-	tdpos.config.initProposer = map[int64][]*candidateInfo{
-		1: []*candidateInfo{
-			&candidateInfo{
+	tdpos.config.initProposer = map[int64][]*CandidateInfo{
+		1: []*CandidateInfo{
+			&CandidateInfo{
 				Address:  "dpzuVdosQrF2kmzumhVeFQZa1aYcdgFpN",
 				PeerAddr: "/ip4/127.0.0.1/tcp/47101/p2p/QmVxeNubpg1ZQY4TmpfV4pvhYT5W17J7TqHSLo6cqq23x3",
 			},
-			&candidateInfo{
+			&CandidateInfo{
 				Address:  "Y4TmpfV4pvhYT5W17J7TqHSLo6cqq23x3",
 				PeerAddr: "/ip4/127.0.0.1/tcp/47102/p2p/QmVxeNubpg1ZQjQT8W5yZC9fD7ZB1ViArwvyGUB53sqf8e",
 			},
-			&candidateInfo{
+			&CandidateInfo{
 				Address:  "RUEMFGDEnLBpnYYggnXukpVfR9Skm59ph",
 				PeerAddr: "/ip4/127.0.0.1/tcp/47103/p2p/U9sKwFmgJVfzgWcfAG47dKn1kLQTqeZN3ZB1ViArwvTmpa",
 			},
-			&candidateInfo{
+			&CandidateInfo{
 				Address:  "bob",
 				PeerAddr: "peerid4",
 			},

--- a/consensus/tdpos/types.go
+++ b/consensus/tdpos/types.go
@@ -86,7 +86,7 @@ type tDposConfig struct {
 	// 投票单价
 	voteUnitPrice *big.Int
 	// 系统指定的前两轮的候选人名单
-	initProposer map[int64][]*candidateInfo
+	initProposer map[int64][]*CandidateInfo
 }
 
 // 每个选票的详情, 支持一票多投
@@ -129,8 +129,8 @@ type candidateBallotsCacheValue struct {
 	isDel bool
 }
 
-// candidateInfo define the candidate info
-type candidateInfo struct {
+// CandidateInfo define the candidate info
+type CandidateInfo struct {
 	Address  string
 	PeerAddr string
 }

--- a/core/xchaincore.go
+++ b/core/xchaincore.go
@@ -1060,7 +1060,8 @@ func (xc *XChainCore) GetDposVotedRecords(addr string) ([]*pb.VotedRecord, error
 
 // GetCheckResults get all proposers for specific term
 func (xc *XChainCore) GetCheckResults(term int64) ([]string, error) {
-	proposers := []string{}
+	res := []string{}
+	proposers := []*tdpos.CandidateInfo{}
 	version := xc.con.Version(xc.Ledger.GetMeta().TrunkHeight + 1)
 	key := tdpos.GenTermCheckKey(version, term)
 	val, err := xc.Utxovm.GetFromTable(nil, []byte(key))
@@ -1071,7 +1072,10 @@ func (xc *XChainCore) GetCheckResults(term int64) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return proposers, nil
+	for _, proposer := range proposers {
+		res = append(res, proposer.Address)
+	}
+	return res, nil
 }
 
 // GetNodeMode get node running mode, such as Normal mode, FastSync mode


### PR DESCRIPTION
## Brief 

This is a bug introduced by p2p peer direct connection.  When using xchain-cli querying tdpos proposers' info, an exception "json: cannot unmarshal object into Go value of type string".
