### PR TITLE
Bugfix: read-only variable [const char* response] is not assignable

### DIFF
--- a/contractsdk/cpp/xchain/syscall.cc
+++ b/contractsdk/cpp/xchain/syscall.cc
@@ -2,7 +2,7 @@
 
 extern "C" uint32_t call_method(const char* method, uint32_t method_len,
                                 const char* request, uint32_t request_len);
-extern "C" uint32_t fetch_response(const char* response, uint32_t response_len);
+extern "C" uint32_t fetch_response(char* response, uint32_t response_len);
 
 namespace xchain {
 
@@ -14,9 +14,9 @@ static bool syscall_raw(const std::string& method, const std::string& request,
     if (response_len <= 0) {
         return true;
     }
-    response->resize(response_len);
+    response->resize(response_len + 1, 0);
     uint32_t success;
-    success = fetch_response(response->data(), response_len);
+    success = fetch_response(&(*response)[0u], response_len);
     return success == 1;
 }
 


### PR DESCRIPTION
## Description

 read-only variable [const char* response] is not assignable

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

Please describe your solution to solve the issue or feature request.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
