### PR TITLE
common transfer no need fee & check gasLimit after  the gas is used

### DIFF
--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -1405,12 +1405,6 @@ func (uv *UtxoVM) verifyTxRWSets(tx *pb.Transaction) (bool, error) {
 	uv.xlog.Trace("get gas limit from tx", "gasLimit", gasLimit, "txid", hex.EncodeToString(tx.Txid))
 
 	for i, tmpReq := range tx.GetContractRequests() {
-		if gasLimit <= 0 {
-			uv.xlog.Error("virifyTxRWSets error:out of gas", "contractName", tmpReq.GetContractName(),
-				"txid", hex.EncodeToString(tx.Txid))
-			return false, errors.New("out of gas")
-		}
-
 		moduleName := tmpReq.GetModuleName()
 		vm, err := uv.vmMgr3.GetVM(moduleName)
 		if err != nil {
@@ -1420,6 +1414,11 @@ func (uv *UtxoVM) verifyTxRWSets(tx *pb.Transaction) (bool, error) {
 		limits := contract.FromPbLimits(tmpReq.GetResourceLimits())
 		if i >= len(reservedRequests) {
 			gasLimit -= limits.TotalGas()
+		}
+		if gasLimit < 0 {
+			uv.xlog.Error("virifyTxRWSets error:out of gas", "contractName", tmpReq.GetContractName(),
+				"txid", hex.EncodeToString(tx.Txid))
+			return false, errors.New("out of gas")
 		}
 		contextConfig.ResourceLimits = limits
 		contextConfig.ContractName = tmpReq.GetContractName()


### PR DESCRIPTION
## Description

What is the purpose of the change?
bugfix: 1.no need to have the flag of --fee for common transfer
             2.check the gasLimit when the gas is used

Fixes #183

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

Please describe your solution to solve the issue or feature request.
Set the checking condition from <= 0 to < 0
Check the gasLimit when the gas is used

## How Has This Been Tested?
client driven test
