### PR TITLE
bugfix:multisig transfer with preExec & reservedContract acl valid 

### DIFF
--- a/cmd/cli/comm_trans.go
+++ b/cmd/cli/comm_trans.go
@@ -92,8 +92,6 @@ func (c *CommTrans) GenPreExeRes(ctx context.Context) (
 		}
 		if tmpReq != nil {
 			preExeReqs = append(preExeReqs, tmpReq)
-		} else if err == nil {
-			return nil, nil, nil
 		}
 	}
 

--- a/utxo/acl_valid_verify.go
+++ b/utxo/acl_valid_verify.go
@@ -102,6 +102,7 @@ func (uv *UtxoVM) verifyContractValid(tx *pb.Transaction) (bool, error) {
 		ok, contractErr := pm.CheckContractMethodPerm(tx.AuthRequire, tx.AuthRequireSigns, digestHash, contractName, methodName, uv.aclMgr)
 		if !ok {
 			uv.xlog.Warn("tx info ", "AuthRequire ", tx.AuthRequire, "AuthRequireSigns ", tx.AuthRequireSigns)
+			return ok, contractErr
 		}
 		if contractErr != nil {
 			return ok, ErrRWAclNotEnough


### PR DESCRIPTION
## Description

What is the purpose of the change?
bugfix1:multisig transfer should go the routine of PreExec because of reserved contracts
bugfix2:when run the function of verifyContractValid in the file of utxo/acl_valid_verify.go, return immediately when ok is false.

Fixes # 188

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

bugfix1: if no InvokeRequest, continue to execute PreExec
bugfix2: when the return value of CheckContractMethodPerm is false, return immediately.

