### PR TITLE
xvm: fix resource leaks when contract initialization fails

### DIFF
--- a/xvm/exec/code.go
+++ b/xvm/exec/code.go
@@ -55,4 +55,5 @@ func (c *Code) Release() {
 	if c.bridgePointer != 0 {
 		pointer.Delete(c.bridgePointer)
 	}
+	*c = Code{}
 }

--- a/xvm/exec/code.go
+++ b/xvm/exec/code.go
@@ -22,27 +22,37 @@ type Code struct {
 
 // NewCode instances a Code object from file path of native shared library
 func NewCode(module string, resolver Resolver) (code *Code, err error) {
-	bridge := newResolverBridge(resolver)
-	bridgePointer := pointer.Save(bridge)
+	code = new(Code)
+	code.bridge = newResolverBridge(resolver)
+	code.bridgePointer = pointer.Save(code.bridge)
+	// xvm_new_code执行期间可能会抛出Trap，导致资源泄露
+	// 如果CaptureTrap捕获了Trap则释放所有已经初始化的资源
+	defer func() {
+		if err != nil {
+			code.Release()
+			code = nil
+		}
+	}()
 	defer CaptureTrap(&err)
 
 	cpath := C.CString(module)
 	defer C.free(unsafe.Pointer(cpath))
-	resolvert := C.make_resolver_t(unsafe.Pointer(bridgePointer))
-	ccode := C.xvm_new_code(cpath, resolvert)
+	resolvert := C.make_resolver_t(unsafe.Pointer(code.bridgePointer))
+	code.code = C.xvm_new_code(cpath, resolvert)
 
-	if ccode == nil {
-		return nil, fmt.Errorf("open module %s error", module)
+	if code.code == nil {
+		err = fmt.Errorf("open module %s error", module)
+		return
 	}
-	return &Code{
-		code:          ccode,
-		bridge:        bridge,
-		bridgePointer: bridgePointer,
-	}, nil
+	return
 }
 
 // Release releases resources hold by Code
 func (c *Code) Release() {
-	C.xvm_release_code(c.code)
-	pointer.Delete(c.bridgePointer)
+	if c.code != nil {
+		C.xvm_release_code(c.code)
+	}
+	if c.bridgePointer != 0 {
+		pointer.Delete(c.bridgePointer)
+	}
 }

--- a/xvm/exec/context.go
+++ b/xvm/exec/context.go
@@ -41,6 +41,12 @@ func NewContext(code *Code, cfg *ContextConfig) (ctx *Context, err error) {
 		cfg:      *cfg,
 		userData: make(map[string]interface{}),
 	}
+	defer func() {
+		if err != nil {
+			ctx.Release()
+			ctx = nil
+		}
+	}()
 	defer CaptureTrap(&err)
 	ret := C.xvm_init_context(&ctx.context, code.code)
 	if ret == 0 {

--- a/xvm/exec/xvm.c
+++ b/xvm/exec/xvm.c
@@ -55,6 +55,15 @@ static bool func_types_are_equal(struct FuncType* a, struct FuncType* b) {
   return 1;
 }
 
+void free_func_type(struct FuncType* ftype) {
+  if (ftype->params != NULL) {
+    free(ftype->params);
+  }
+  if (ftype->results != NULL) {
+    free(ftype->results);
+  }
+}
+
 static uint32_t wasm_rt_register_func_type(void* context,
                                     uint32_t param_count,
                                     uint32_t result_count,
@@ -233,8 +242,16 @@ xvm_code_t* xvm_new_code(char* module_path, xvm_resolver_t resolver) {
 }
 
 void xvm_release_code(xvm_code_t* code) {
-  free(code->func_types);
-  dlclose(code->dlhandle);
+  if (code->func_types != NULL) {
+    int i = 0;
+    for (; i<code->func_type_count; i++) {
+      free_func_type(code->func_types + i);
+    }
+    free(code->func_types);
+  }
+  if (code->dlhandle != NULL) {
+    dlclose(code->dlhandle);
+  }
   free(code);
 }
 

--- a/xvm/exec/xvm.c
+++ b/xvm/exec/xvm.c
@@ -253,6 +253,7 @@ void xvm_release_code(xvm_code_t* code) {
     dlclose(code->dlhandle);
   }
   free(code);
+  memset((void*)code, 0, sizeof(xvm_code_t));
 }
 
 /*
@@ -293,6 +294,7 @@ void xvm_release_context(xvm_context_t* ctx) {
   if (ctx->module_handle != NULL) {
     free(ctx->module_handle);
   }
+  memset((void*)ctx, 0, sizeof(xvm_context_t));
 }
 
 uint32_t xvm_call(xvm_context_t* ctx, char* name, uint32_t* params, uint32_t param_len, wasm_rt_gas_t* gas, uint32_t* ret) {


### PR DESCRIPTION
A trap may occur during the execution of NewCode and NewContext, resulting in resource leaks.
This commit make resource cleanup when initialization fails.
