### PR TITLE
fix bug: cmd/cli generates tx output including a zero amount

### DIFF
--- a/cmd/cli/comm_trans.go
+++ b/cmd/cli/comm_trans.go
@@ -272,8 +272,12 @@ func (c *CommTrans) GenTxOutputs(gasUsed int64) ([]*pb.TxOutput, *big.Int, error
 		if !ok {
 			return nil, nil, ErrInvalidAmount
 		}
-		if amount.Cmp(bigZero) < 0 {
+		cmpRes := amount.Cmp(bigZero)
+		if cmpRes < 0 {
 			return nil, nil, ErrNegativeAmount
+		} else if cmpRes == 0 {
+			// trim 0 output
+			continue
 		}
 		// 得到总的转账金额
 		totalNeed.Add(totalNeed, amount)


### PR DESCRIPTION
## Description

cmd/cli generates tx output including a zero amount for CommTrans operations like contract deploy/invoke. 

Fixes #202 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution

This PR will trim tx outputs with an amount of zero.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
