### PR TITLE
badger iterator fix first & last

### DIFF
--- a/kv/kvdb/plugin-badger/iter.go
+++ b/kv/kvdb/plugin-badger/iter.go
@@ -131,7 +131,7 @@ func (iter *BadgerIterator) Prev() bool {
 
 // Last skip to the last iterator
 func (iter *BadgerIterator) Last() bool {
-	key := iter.first
+	key := iter.Key()
 	for iter.Next() {
 		key = iter.Key()
 	}
@@ -154,11 +154,12 @@ func (iter *BadgerIterator) Last() bool {
 
 // First skip to the first iterator
 func (iter *BadgerIterator) First() bool {
-	key := iter.first
+	key := iter.Key()
 	for iter.Prev() {
 		key = iter.Key()
 	}
 	iter.badgerIter.Seek(key)
+
 	return true
 }
 


### PR DESCRIPTION
## Description

What is the purpose of the change?
Purpose:
Make badger iterator works well
Context:
When the xchain node needs to invoke getTermProposer so as to get the proposer of a particular term, the xchain service uses the iterator to get the particular term's key and value involved with the iterator of first() and last() and prev(), it needs to storage the last iterator's key instead of the prefixKey.

Fixes #174 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

Please describe your solution to solve the issue or feature request.
Store the last iterator's key instead of the prefixKey.

## How Has This Been Tested?
Client-Driven Test
