### PR TITLE
add p2p config for the number of broadcast peers

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -25,7 +25,9 @@ const (
 	DefaultIsAuthentication = false
 	DefautltAuthTimeout     = 30
 	// limitation size for same ip
-	DefaultStreamIPLimitSize = 10
+	DefaultStreamIPLimitSize     = 10
+	DefaultMaxBroadcastPeers     = 20
+	DefaultMaxBroadcastCorePeers = 10
 )
 
 // LogConfig is the log config of node
@@ -84,6 +86,13 @@ type P2PConfig struct {
 	IsAuthentication bool `yaml:"isauthentication,omitempty"`
 	// StreamIPLimitSize set the limitation size for same ip
 	StreamIPLimitSize int64 `yaml:"streamIPLimitSize,omitempty"`
+	// MaxBroadcastPeers limit the number of common peers in a broadcast,
+	// this number do not include MaxBroadcastCorePeers.
+	MaxBroadcastPeers int `yaml:"maxBroadcastPeers,omitempty"`
+	// MaxBroadcastCorePeers limit the number of core peers in a broadcast,
+	// this only works when NodeConfig.CoreConnection is true. Note that the number
+	// of core peers is included in MaxBroadcastPeers.
+	MaxBroadcastCorePeers int `yaml:"maxBroadcastCorePeers,omitempty"`
 }
 
 // MinerConfig is the config of miner
@@ -307,7 +316,9 @@ func newP2pConfigWithDefault() P2PConfig {
 		Timeout:          DefaultTimeout,
 		IsAuthentication: DefaultIsAuthentication,
 		// default stream ip limit size
-		StreamIPLimitSize: DefaultStreamIPLimitSize,
+		StreamIPLimitSize:     DefaultStreamIPLimitSize,
+		MaxBroadcastPeers:     DefaultMaxBroadcastPeers,
+		MaxBroadcastCorePeers: DefaultMaxBroadcastCorePeers,
 	}
 }
 

--- a/p2pv2/node.go
+++ b/p2pv2/node.go
@@ -107,7 +107,6 @@ func NewNode(cfg config.P2PConfig, log log.Logger) (*Node, error) {
 	// set broadcast peers limitation
 	MaxBroadCastPeers = cfg.MaxBroadcastPeers
 	MaxBroadCastCorePeers = cfg.MaxBroadcastCorePeers
-	log.Warn("++++test", "peers", MaxBroadCastPeers, "corepeers", MaxBroadCastCorePeers)
 
 	// initialize StreamLimit, set limit size
 	no.streamLimit.Init(cfg.StreamIPLimitSize, log)

--- a/p2pv2/node.go
+++ b/p2pv2/node.go
@@ -26,9 +26,14 @@ import (
 
 // define the common config
 const (
-	XuperProtocolID       = "/xuper/2.0.0" // protocol version
-	MaxBroadCastPeers     = 20             // the maximum peers to broadcast messages
-	MaxBroadCastCorePeers = 10             // the maximum core peers to broadcast messages
+	XuperProtocolID = "/xuper/2.0.0" // protocol version
+)
+
+var (
+	// MaxBroadCastPeers define the maximum number of common peers to broadcast messages
+	MaxBroadCastPeers = 20
+	// MaxBroadCastCorePeers define the maximum number of core peers to broadcast messages
+	MaxBroadCastCorePeers = 10
 )
 
 // define errors
@@ -98,6 +103,12 @@ func NewNode(cfg config.P2PConfig, log log.Logger) (*Node, error) {
 		// new StreamLimit
 		streamLimit: &StreamLimit{},
 	}
+
+	// set broadcast peers limitation
+	MaxBroadCastPeers = cfg.MaxBroadcastPeers
+	MaxBroadCastCorePeers = cfg.MaxBroadcastCorePeers
+	log.Warn("++++test", "peers", MaxBroadCastPeers, "corepeers", MaxBroadCastCorePeers)
+
 	// initialize StreamLimit, set limit size
 	no.streamLimit.Init(cfg.StreamIPLimitSize, log)
 	ho.SetStreamHandler(XuperProtocolID, no.handlerNewStream)


### PR DESCRIPTION
## Description

Add p2p config for the number of broadcast peers (both common peers and core peers), so user can change the broadcast peer number in xchain.yml

Fixes #213 

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Brief of your solution

Use config like below to change the broadcast peer number:

```yml
p2pV2:
  port: 47101
  maxBroadcastPeers: 30
  maxBroadcastCorePeers: 10
```

## How Has This Been Tested?

passed `make test` and checked the config value in log.
