### PR TITLE
fix bug of negative utxo version may skip signature check

### DIFF
--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -1177,7 +1177,7 @@ func (uv *UtxoVM) ImmediateVerifyTx(tx *pb.Transaction, isRootTx bool) (bool, er
 	if !isRootTx && tx.Version == RootTxVersion {
 		return false, ErrVersionInvalid
 	}
-	if tx.Version > BetaTxVersion {
+	if tx.Version > BetaTxVersion || tx.Version < RootTxVersion {
 		return false, ErrVersionInvalid
 	}
 	// autogen tx should not run ImmediateVerifyTx, this could be a fake tx
@@ -1188,7 +1188,7 @@ func (uv *UtxoVM) ImmediateVerifyTx(tx *pb.Transaction, isRootTx bool) (bool, er
 		uv.xlog.Warn("tx too large, should not be greater than half of max blocksize", "size", proto.Size(tx))
 		return false, ErrTxTooLarge
 	}
-	if tx.Version >= TxVersion {
+	if tx.Version > RootTxVersion {
 		// verify rwset
 		ok, err := uv.verifyTxRWSets(tx)
 		if err != nil && strings.HasPrefix(err.Error(), "Gas not enough") {


### PR DESCRIPTION
## Description

Negative tx version is skipped in utxo verification so that attackers could 'steal' utxo resources without any signatures.

This bug is first reported in PR #227 and should also be fixed in V3.2

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution

Check tx.Version and make sure all transactions from client should be verified.
