### PR TITLE
Heaviest chain interface

### DIFF
--- a/consensus/base/consensusinterface.go
+++ b/consensus/base/consensusinterface.go
@@ -28,4 +28,8 @@ type ConsensusInterface interface {
 
 	// Get consensus status
 	GetStatus() *ConsensusStatus
+
+	// GetHeaviestChain return heaviest chain while dealing with fork
+	// Different consensus may have different
+	GetHeaviestChain(tipBlocks []*pb.InternalBlock) (*pb.InternalBlock, error)
 }

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -492,3 +492,9 @@ func (pc *PluggableConsensus) GetStatus() *cons_base.ConsensusStatus {
 	currentConsIndex := len(pc.cons) - 1
 	return pc.cons[currentConsIndex].Conn.GetStatus()
 }
+
+// GetHeaviestChain return heaviest chain while dealing with fork
+func (pc *PluggableConsensus) GetHeaviestChain(tipBlocks []*pb.InternalBlock) (*pb.InternalBlock, error) {
+	currentConsIndex := len(pc.cons) - 1
+	return pc.cons[currentConsIndex].Conn.GetHeaviestChain(tipBlocks)
+}

--- a/consensus/pow/pow.go
+++ b/consensus/pow/pow.go
@@ -163,3 +163,9 @@ func (pc *PowConsensus) GetCoreMiners() []*cons_base.MinerInfo {
 func (pc *PowConsensus) GetStatus() *cons_base.ConsensusStatus {
 	return &cons_base.ConsensusStatus{}
 }
+
+// GetHeaviestChain return heaviest chain while dealing with fork
+// TODO zq
+func (pc *PowConsensus) GetHeaviestChain(tipBlocks []*pb.InternalBlock) (*pb.InternalBlock, error) {
+	return nil, nil
+}

--- a/consensus/single/singleconsenus.go
+++ b/consensus/single/singleconsenus.go
@@ -189,3 +189,9 @@ func (sc *SingleConsensus) GetStatus() *cons_base.ConsensusStatus {
 		Proposer: string(sc.masterAddr),
 	}
 }
+
+// GetHeaviestChain return heaviest chain while dealing with fork
+// TODO zq
+func (sc *SingleConsensus) GetHeaviestChain(tipBlocks []*pb.InternalBlock) (*pb.InternalBlock, error) {
+	return nil, nil
+}

--- a/consensus/tdpos/tdpos.go
+++ b/consensus/tdpos/tdpos.go
@@ -579,3 +579,9 @@ func (tp *TDpos) GetStatus() *cons_base.ConsensusStatus {
 	}
 	return status
 }
+
+// GetHeaviestChain return heaviest chain while dealing with fork
+// TODO zq
+func (tp *TDpos) GetHeaviestChain(tipBlocks []*pb.InternalBlock) (*pb.InternalBlock, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## Description

What is the purpose of the change?

`Consensus` module support an interface `GetHeaviestChain`, so that different consensus can easy to deal with fork according to their rule.

Fixes #235 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

```
type ConsensusInterface interface {
        // ......
	// GetHeaviestChain return heaviest chain while dealing with fork
	// Different consensus may have different
	GetHeaviestChain(tipBlocks []*pb.InternalBlock) (*pb.InternalBlock, error)
}
```

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
