### PR TITLE
Improvement: no need to forbid any tx if reserved contract is not available

### DIFF
--- a/data/config/reservedroot.json
+++ b/data/config/reservedroot.json
@@ -52,14 +52,12 @@
                 "args":{}
             }
         ]
-        , "forbidden_contract": [
-            {
+        , "forbidden_contract": {
                 "module_name": "wasm",
                 "contract_name": "forbidden",
                 "method_name": "get",
                 "args":{}
-            }
-        ]
+        }
         , "permission": {
                 "CreateAccount" : { "rule" : "Null", "acl": {}},
                 "SetAccountAcl": { "rule" : "Null", "acl": {}},

--- a/data/config/reservedroot.json
+++ b/data/config/reservedroot.json
@@ -52,6 +52,14 @@
                 "args":{}
             }
         ]
+        , "forbidden_contract": [
+            {
+                "module_name": "wasm",
+                "contract_name": "forbidden",
+                "method_name": "get",
+                "args":{}
+            }
+        ]
         , "permission": {
                 "CreateAccount" : { "rule" : "Null", "acl": {}},
                 "SetAccountAcl": { "rule" : "Null", "acl": {}},

--- a/ledger/genesis.go
+++ b/ledger/genesis.go
@@ -36,6 +36,7 @@ type RootConfig struct {
 	Decimals          string                 `json:"decimals"`
 	GenesisConsensus  map[string]interface{} `json:"genesis_consensus"`
 	ReservedContracts []InvokeRequest        `json:"reserved_contracts"`
+	ForbiddenContract []InvokeRequest        `json:"forbidden_contract"`
 }
 
 // InvokeRequest define genesis reserved_contracts configure

--- a/ledger/genesis.go
+++ b/ledger/genesis.go
@@ -36,7 +36,7 @@ type RootConfig struct {
 	Decimals          string                 `json:"decimals"`
 	GenesisConsensus  map[string]interface{} `json:"genesis_consensus"`
 	ReservedContracts []InvokeRequest        `json:"reserved_contracts"`
-	ForbiddenContract []InvokeRequest        `json:"forbidden_contract"`
+	ForbiddenContract InvokeRequest          `json:"forbidden_contract"`
 }
 
 // InvokeRequest define genesis reserved_contracts configure

--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -1719,8 +1719,6 @@ func (uv *UtxoVM) queryTxFromForbiddenWithConfirmed(txid []byte) (bool, bool, er
 	contractNameForForbidden := forbiddenContract[0].ContractName
 	methodNameForForbidden := forbiddenContract[0].MethodName
 
-	uv.xlog.Warn("xxxxxxxxxxxx forbiddenContract->", forbiddenContract)
-
 	request := &pb.InvokeRequest{
 		ModuleName:   moduleNameForForbidden,
 		ContractName: contractNameForForbidden,

--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -1712,12 +1712,11 @@ func (uv *UtxoVM) queryAccountContainAK(address string) ([]string, error) {
 func (uv *UtxoVM) queryTxFromForbiddenWithConfirmed(txid []byte) (bool, bool, error) {
 	// 如果配置文件配置了封禁tx监管合约，那么继续下面的执行。否则，直接返回.
 	forbiddenContract := uv.ledger.GenesisBlock.GetConfig().ForbiddenContract
-	if len(forbiddenContract) != 1 {
-		return false, false, errors.New("there are some problems with forbidden contract configuration")
-	}
-	moduleNameForForbidden := forbiddenContract[0].ModuleName
-	contractNameForForbidden := forbiddenContract[0].ContractName
-	methodNameForForbidden := forbiddenContract[0].MethodName
+
+	// 这里不针对ModuleName/ContractName/MethodName做特殊化处理
+	moduleNameForForbidden := forbiddenContract.ModuleName
+	contractNameForForbidden := forbiddenContract.ContractName
+	methodNameForForbidden := forbiddenContract.MethodName
 
 	request := &pb.InvokeRequest{
 		ModuleName:   moduleNameForForbidden,

--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -1710,6 +1710,10 @@ func (uv *UtxoVM) queryAccountContainAK(address string) ([]string, error) {
 }
 
 func (uv *UtxoVM) queryTxFromForbiddenWithConfirmed(txid []byte) (bool, bool, error) {
+	// 如果配置文件配置了监管合约，那么继续下面的执行。否则，直接返回.
+	if len(uv.ledger.GenesisBlock.GetConfig().ReservedContracts) <= 0 {
+		return false, false, errors.New("no need to forbidden any transaction because of a common blockchain system")
+	}
 	request := &pb.InvokeRequest{
 		ModuleName:   "wasm",
 		ContractName: "forbidden",


### PR DESCRIPTION
## Description

What is the purpose of the change?
When the xuperchain is under non-reserved contracts, the contract of forbidden couldn't work.

Fixes #264 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

Please describe your solution to solve the issue or feature request.
Check if the rootConfig has the configurations of reserved contracts before invoking the contract of forbidden.

## How Has This Been Tested?

Regresstion Test
