### PR TITLE
bugfix: query accounts by ak for AKSets is not available

### DIFF
--- a/contract/kernel/ak_2_account.go
+++ b/contract/kernel/ak_2_account.go
@@ -47,7 +47,7 @@ func updateAkSetWithPut(ctx *KContext, sets map[string]*pb.AkSet, accountName st
 	for _, akSets := range sets {
 		for _, ak := range akSets.GetAks() {
 			key := utils.MakeAK2AccountKey(ak, accountName)
-			err := ctx.ModelCache.Del(utils.GetAK2AccountBucket(), []byte(key))
+			err := ctx.ModelCache.Put(utils.GetAK2AccountBucket(), []byte(key), []byte("true"))
 			if err != nil {
 				return err
 			}

--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -713,7 +713,7 @@ func (uv *UtxoVM) PreExec(req *pb.InvokeRPCRequest, hd *global.XContext) (*pb.In
 	}
 	// contract request with reservedRequests
 	req.Requests = append(reservedRequests, req.Requests...)
-	uv.xlog.Error("PreExec requests after merge", "requests", req.Requests)
+	uv.xlog.Trace("PreExec requests after merge", "requests", req.Requests)
 	// init modelCache
 	modelCache, err := xmodel.NewXModelCache(uv.GetXModel(), true)
 	if err != nil {


### PR DESCRIPTION
Description

What is the purpose of the change?
bugfix: fix the bug that query accounts by ak for AKSets is not available.

Fixes #282

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

Fix the API of updateAkSetWithPut, form Del to Put.

## How Has This Been Tested?

Regression Test
