### PR TITLE
cherry-pick to V3.2: Reserved contract support white list

### DIFF
--- a/data/config/reservedroot.json
+++ b/data/config/reservedroot.json
@@ -1,0 +1,63 @@
+{
+    "version" : "1"
+    , "predistribution":[
+        {
+            "address" : "dpzuVdosQrF2kmzumhVeFQZa1aYcdgFpN"
+            , "quota" : "100000000000000000000"
+        }
+    ]
+    , "maxblocksize" : "128"
+    , "award" : "1000000"
+    , "decimals" : "8"
+    , "award_decay": {
+        "height_gap": 31536000,
+        "ratio": 1
+    }, "genesis_consensus":{
+        "name": "tdpos",
+        "config": {
+                "timestamp": "1548123921000000000",
+                "proposer_num":"1",
+                "period":"3000",
+                "alternate_interval":"6000",
+                "term_interval":"9000",
+                "block_num":"200",
+                "vote_unit_price":"1",
+                "init_proposer": {
+                        "1":["dpzuVdosQrF2kmzumhVeFQZa1aYcdgFpN"]
+                },
+                "init_proposer_neturl": {
+                     "1": ["/ip4/127.0.0.1/tcp/47101/p2p/QmUqM5tGMZCuHEBcGYbxUHr2yzLdXSBGc5ziPHm68CuqzC"]
+                }
+           }
+        }
+        , "reserved_contracts": [
+            {
+                "module_name": "wasm",
+                "contract_name": "banned",
+                "method_name": "verify",
+                "args": {
+                    "contract": "{{.ContractNames}}"
+                }
+            },
+            {
+                "module_name": "wasm",
+                "contract_name": "identity",
+                "method_name": "verify",
+                "args":{}
+            },
+            {
+                "module_name": "wasm",
+                "contract_name": "complianceCheck",
+                "method_name": "call",
+                "args":{}
+            }
+        ]
+        ,"reserved_whitelist": {
+            "account": "XC9999999999999999@xuper"
+        } 
+        , "permission": {
+                "CreateAccount" : { "rule" : "Null", "acl": {}},
+                "SetAccountAcl": { "rule" : "Null", "acl": {}},
+                "SetContractMethodAcl": { "rule" : "Null", "acl": {}}
+       }
+}

--- a/ledger/genesis.go
+++ b/ledger/genesis.go
@@ -36,6 +36,9 @@ type RootConfig struct {
 	Decimals          string                 `json:"decimals"`
 	GenesisConsensus  map[string]interface{} `json:"genesis_consensus"`
 	ReservedContracts []InvokeRequest        `json:"reserved_contracts"`
+	ReservedWhitelist struct {
+		Account string `json:"account"`
+	} `json:"reserved_whitelist"`
 }
 
 // InvokeRequest define genesis reserved_contracts configure
@@ -87,6 +90,11 @@ func (rc *RootConfig) GetGenesisConsensus() (map[string]interface{}, error) {
 // GetReservedContract get default contract config of genesis block
 func (rc *RootConfig) GetReservedContract() ([]*pb.InvokeRequest, error) {
 	return invokeRequestFromJSON2Pb(rc.ReservedContracts)
+}
+
+// GetReservedWhitelistAccount return reserved whitelist account
+func (rc *RootConfig) GetReservedWhitelistAccount() string {
+	return rc.ReservedWhitelist.Account
 }
 
 // GenesisBlock genesis block data structure

--- a/utxo/reserved_contract.go
+++ b/utxo/reserved_contract.go
@@ -23,6 +23,79 @@ func genArgs(req []*pb.InvokeRequest) *reservedArgs {
 	return ra
 }
 
+// It will check whether the transaction in reserved whitelist
+// if the config of chain contains reserved contracts
+// but the transaction does not contains reserved requests.
+func (uv *UtxoVM) verifyReservedWhitelist(tx *pb.Transaction) bool {
+	// verify reservedContracts len
+	reservedContracts, err := uv.ledger.GenesisBlock.GetConfig().GetReservedContract()
+	if len(reservedContracts) == 0 {
+		uv.xlog.Info("verifyReservedWhitelist false reservedReqs is nil")
+		return false
+	}
+
+	// get white list account
+	accountName := uv.ledger.GetGenesisBlock().GetConfig().GetReservedWhitelistAccount()
+	uv.xlog.Trace("verifyReservedWhitelist", "accountName", accountName)
+	if accountName == "" {
+		uv.xlog.Info("verifyReservedWhitelist false, the chain does not have reserved whitelist", "accountName", accountName)
+		return false
+	}
+	acl, isConfirmed, err := uv.aclMgr.GetAccountACLWithConfirmed(accountName)
+	if err != nil || acl == nil || !isConfirmed {
+		uv.xlog.Info("verifyReservedWhitelist false, get reserved whitelist acl failed",
+			"err", err, "acl", acl, "isConfirmed", isConfirmed)
+		return false
+	}
+
+	// verify storage
+	if tx.GetDesc() != nil ||
+		tx.GetContractRequests() != nil ||
+		tx.GetTxInputsExt() != nil ||
+		tx.GetTxOutputsExt() != nil {
+		uv.xlog.Info("verifyReservedWhitelist false the storage info should be nil")
+		return false
+	}
+
+	// verify utxo input
+	if len(tx.GetTxInputs()) == 0 && len(tx.GetTxOutputs()) == 0 {
+		uv.xlog.Info("verifyReservedWhitelist true the utxo list is nil")
+		return true
+	}
+	fromAddr := string(tx.GetTxInputs()[0].GetFromAddr())
+	for _, v := range tx.GetTxInputs() {
+		if string(v.GetFromAddr()) != fromAddr {
+			uv.xlog.Info("verifyReservedWhitelist false fromAddr should no more than one")
+			return false
+		}
+	}
+
+	// verify utxo output
+	toAddrs := make(map[string]bool)
+	for _, v := range tx.GetTxOutputs() {
+		if bytes.Equal(v.GetToAddr(), []byte(FeePlaceholder)) {
+			continue
+		}
+		toAddrs[string(v.GetToAddr())] = true
+		if len(toAddrs) > 2 {
+			uv.xlog.Info("verifyReservedWhitelist false toAddrs should no more than two")
+			return false
+		}
+	}
+
+	// verify utxo output whitelist
+	for k := range toAddrs {
+		if k == fromAddr {
+			continue
+		}
+		if _, ok := acl.GetAksWeight()[k]; !ok {
+			uv.xlog.Info("verifyReservedWhitelist false the toAddr should in whitelist acl")
+			return false
+		}
+	}
+	return true
+}
+
 func verifyReservedContractRequests(reservedReqs, txReqs []*pb.InvokeRequest) bool {
 	if len(reservedReqs) > len(txReqs) {
 		return false

--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -1370,6 +1370,11 @@ func getGasLimitFromTx(tx *pb.Transaction) (int64, error) {
 
 // verifyTxRWSets verify tx read sets and write sets
 func (uv *UtxoVM) verifyTxRWSets(tx *pb.Transaction) (bool, error) {
+	if uv.verifyReservedWhitelist(tx) {
+		uv.xlog.Info("verifyReservedWhitelist true", "txid", fmt.Sprintf("%x", tx.GetTxid()))
+		return true, nil
+	}
+
 	req := tx.GetContractRequests()
 	reservedRequests, err := uv.getReservedContractRequests(tx.GetContractRequests(), false)
 	if err != nil {


### PR DESCRIPTION
## Description

What is the purpose of the change?
At present, all transactions need to be checked by ReservedContracts. It is not suitable for some special scenarios.

Fixes #271 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

The config of chain may support ReservedWhitelist, so that some transactions can not pass the inspection of ReservedContracts.
```
 ,"reserved_whitelist": {
     "account": "XC9999999999999999@xuper"
} 
```

## How Has This Been Tested?
It can be tested by changing `cmd/cli/cli.go` or calling `posttx` interface.