### PR TITLE
Improvement: Unconfirm transactions are reposted when a time window slides

### DIFF
--- a/common/batch_chan.go
+++ b/common/batch_chan.go
@@ -34,7 +34,6 @@ func (bc *BatchChan) loopMakeBatch() {
 	timer := time.Tick(time.Millisecond * time.Duration(bc.waitms))
 	buffer := []*pb.Transaction{}
 	timeFlag := false
-	//lastTimestamp = time.Now().UnixNano()
 	for {
 		select {
 		case item := <-bc.itemChan:

--- a/common/batch_chan.go
+++ b/common/batch_chan.go
@@ -42,9 +42,9 @@ func (bc *BatchChan) loopMakeBatch() {
 			timeFlag = true
 		}
 
-		// 容量控制 + 时间控制
+		// 数量控制 + 时间控制
 		// case1: 当buffer中积攒的unconfirm transactions数量超过bc.window
-		// case2: 当经过bc.waitms事件后
+		// case2: 当经过bc.waitms时间窗口后
 		// case1以及case2都需要转发本地buffer中的unconfirm transactions
 		if len(buffer) >= bc.window || (len(buffer) > 0 && timeFlag == true) {
 			bc.queue <- buffer

--- a/common/batch_chan.go
+++ b/common/batch_chan.go
@@ -33,16 +33,26 @@ func NewBatchChan(window int, waitms int, itemChan chan *pb.Transaction) *BatchC
 func (bc *BatchChan) loopMakeBatch() {
 	timer := time.Tick(time.Millisecond * time.Duration(bc.waitms))
 	buffer := []*pb.Transaction{}
+	timeFlag := false
+	//lastTimestamp = time.Now().UnixNano()
 	for {
 		select {
 		case item := <-bc.itemChan:
 			buffer = append(buffer, item)
 		case <-timer:
+			timeFlag = true
 		}
-		if len(buffer) >= bc.window {
+
+		// 容量控制 + 时间控制
+		// case1: 当buffer中积攒的unconfirm transactions数量超过bc.window
+		// case2: 当经过bc.waitms事件后
+		// case1以及case2都需要转发本地buffer中的unconfirm transactions
+		if len(buffer) >= bc.window || (len(buffer) > 0 && timeFlag == true) {
 			bc.queue <- buffer
 			buffer = []*pb.Transaction{}
+			timeFlag = false
 		}
+
 	}
 }
 


### PR DESCRIPTION
## Description

What is the purpose of the change?
Make sure that other xchain nodes in the network of blockchain could receive unconfirmed transactions distributed from different xchain nodes so that the transaction could be dealt with as soon as possible.

Fixes #293 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] A kind of improvement

## Brief of your solution

Make unconfirmed transactions be reposted when a time window slides

## How Has This Been Tested?

Regression Test
