### PR TITLE
bugfix: add separator string when doing the ops of GetAccountContracts

### DIFF
--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -1993,7 +1993,7 @@ func (uv *UtxoVM) GetAccountContracts(account string) ([]string, error) {
 		uv.xlog.Warn("GetAccountContracts valid account name error", "error", "account name is not valid")
 		return nil, errors.New("account name is not valid")
 	}
-	prefKey := pb.ExtUtxoTablePrefix + string(xmodel.MakeRawKey(utils.GetAccount2ContractBucket(), []byte(account)))
+	prefKey := pb.ExtUtxoTablePrefix + string(xmodel.MakeRawKey(utils.GetAccount2ContractBucket(), []byte(account+utils.GetACLSeparator())))
 	it := uv.ldb.NewIteratorWithPrefix([]byte(prefKey))
 	defer it.Release()
 	for it.Next() {


### PR DESCRIPTION
## Description

What is the purpose of the change?
Fix the bug of GetAccountContracts.

Fixes #296 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

add separator string when doing the ops of GetAccountContracts

## How Has This Been Tested?

Regression Test
