### PR TITLE
cherry-pick bugfix: split utxo need preexec and nominate address can …

### DIFF
--- a/consensus/tdpos/common.go
+++ b/consensus/tdpos/common.go
@@ -302,14 +302,12 @@ func (tp *TDpos) validateNominateCandidate(desc *contract.TxDesc) (*CandidateInf
 	if desc.Args["candidate"] == nil {
 		return nil, "", errors.New("validateNominateCandidate candidate can not be null")
 	}
-	switch desc.Args["candidate"].(type) {
-	case string:
-		candidate := desc.Args["candidate"].(string)
-		if checkCandidateName(candidate) {
+	if candidate, ok := desc.Args["candidate"].(string); ok {
+		if !checkCandidateName(candidate) {
 			return nil, "", errors.New("validateNominateCandidate candidate name invalid")
 		}
 		canInfo.Address = candidate
-	default:
+	} else {
 		return nil, "", errors.New("validateNominateCandidate candidates should be string")
 	}
 

--- a/consensus/tdpos/storage.go
+++ b/consensus/tdpos/storage.go
@@ -137,5 +137,8 @@ func genRevokeKey(txid string) string {
 }
 
 func checkCandidateName(name string) bool {
-	return strings.Contains("name", "_")
+	if name == "" {
+		return false
+	}
+	return !strings.Contains(name, "_")
 }


### PR DESCRIPTION
## Description

What is the purpose of the change?

There are some problems.

- Split utxo cmd need to preExec before post to server.

- And the candidate can be nil while nominating.

Fixes #297 #294 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution

- `Split utxo` cmd need to preExec before post to server.

- The candidate need to be address while nominating.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
