### PR TITLE
optimization: use BlockHeader instead of Block with body

### DIFF
--- a/core/sync.go
+++ b/core/sync.go
@@ -46,7 +46,7 @@ func (xc *XChainCore) SyncBlocks() {
 	}
 }
 
-// syncForOnce sync block from peer nodes for one times
+// syncForOnce sync block from peer nodes once
 func (xc *XChainCore) syncForOnce() (*pb.BCStatus, bool) {
 	bcs := &pb.BCStatus{Bcname: xc.bcname}
 	bcsBuf, _ := proto.Marshal(bcs)
@@ -76,7 +76,7 @@ func countGetBlockChainStatus(hbcs []*xuper_p2p.XuperMessage) *pb.BCStatus {
 	p := hbcs[0]
 	maxCount := 0
 	countHeight := make(map[int64]int)
-	for i := 1; i < len(hbcs); i++ {
+	for i := 0; i < len(hbcs); i++ {
 		bcStatus := &pb.BCStatus{}
 		err := proto.Unmarshal(p.GetData().GetMsgInfo(), bcStatus)
 		if err != nil {

--- a/core/sync.go
+++ b/core/sync.go
@@ -76,7 +76,7 @@ func countGetBlockChainStatus(hbcs []*xuper_p2p.XuperMessage) *pb.BCStatus {
 	p := hbcs[0]
 	maxCount := 0
 	countHeight := make(map[int64]int)
-	for i := 0; i < len(hbcs); i++ {
+	for i := 1; i < len(hbcs); i++ {
 		bcStatus := &pb.BCStatus{}
 		err := proto.Unmarshal(p.GetData().GetMsgInfo(), bcStatus)
 		if err != nil {

--- a/core/xchaincore.go
+++ b/core/xchaincore.go
@@ -915,7 +915,8 @@ func (xc *XChainCore) GetBlockChainStatus(in *pb.BCStatus) *pb.BCStatus {
 	utxoMeta := xc.Utxovm.GetMeta()
 	out.UtxoMeta = utxoMeta
 
-	ib, err := xc.Ledger.QueryBlock(meta.TipBlockid)
+	//ib, err := xc.Ledger.QueryBlock(meta.TipBlockid)
+	ib, err := xc.Ledger.QueryBlockHeader(meta.TipBlockid)
 	if err != nil {
 		out.Header.Error = HandlerLedgerError(err)
 		return out

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -823,18 +823,10 @@ func (l *Ledger) QueryBlock(blockid []byte) (*pb.InternalBlock, error) {
 
 // QueryBlockHeader query a block by blockID in the ledger and return only block header
 func (l *Ledger) QueryBlockHeader(blockid []byte) (*pb.InternalBlock, error) {
-	blkInCache, exist := l.blockCache.Get(string(blockid))
-	if exist {
-		l.xlog.Debug("hit queryblock cache", "blkid", global.F(blockid))
-		tmpBlock := *blkInCache.(*pb.InternalBlock)
-		tmpBlock.Transactions = nil
-		return &tmpBlock, nil
-	}
-	blk, err := l.queryBlock(blockid, true)
+	blk, err := l.QueryBlock(blockid)
 	if err != nil {
 		return nil, err
 	}
-	l.blockCache.Add(string(blockid), blk)
 	tmpBlock := *blk
 	tmpBlock.Transactions = nil
 	//return l.queryBlock(blockid, false)

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -823,6 +823,13 @@ func (l *Ledger) QueryBlock(blockid []byte) (*pb.InternalBlock, error) {
 
 // QueryBlockHeader query a block by blockID in the ledger and return only block header
 func (l *Ledger) QueryBlockHeader(blockid []byte) (*pb.InternalBlock, error) {
+	blkInCache, exist := l.blockCache.Get(string(blockid))
+	if exist {
+		l.xlog.Debug("hit queryblock cache", "blkid", global.F(blockid))
+		tmpBlock := *blkInCache.(*pb.InternalBlock)
+		tmpBlock.Transactions = nil
+		return &tmpBlock, nil
+	}
 	return l.queryBlock(blockid, false)
 }
 

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -830,7 +830,15 @@ func (l *Ledger) QueryBlockHeader(blockid []byte) (*pb.InternalBlock, error) {
 		tmpBlock.Transactions = nil
 		return &tmpBlock, nil
 	}
-	return l.queryBlock(blockid, false)
+	blk, err := l.queryBlock(blockid, true)
+	if err != nil {
+		return nil, err
+	}
+	l.blockCache.Add(string(blockid), blk)
+	tmpBlock := *blk
+	tmpBlock.Transactions = nil
+	//return l.queryBlock(blockid, false)
+	return &tmpBlock, nil
 }
 
 // HasTransaction check if a transaction exists in the ledger


### PR DESCRIPTION
## Description

What is the purpose of the change?
Optimization: shorten the time of syncForOnce during the process of SyncBlocks to make sure that the miner generates a new block on time.

Fixes #336

## Type of change
- [x] Improvement 

## Brief of your solution

Please describe your solution to solve the issue or feature request.
Use the function of QueryBlockWithHeader instead of the function of QueryBlock

## How Has This Been Tested?

Regression Test & Pressure Test