### PR TITLE
bugfix: reset pow minning state before dominer

### DIFF
--- a/ledger/calc_nonce.go
+++ b/ledger/calc_nonce.go
@@ -35,7 +35,6 @@ func (l *Ledger) processFormatBlockForPOW(block *pb.InternalBlock, targetBits in
 	// l.IsEnablePowMinning() == true  --> 自己挖出块
 	// l.IsEnablePowMinning() == false --> 被中断
 	if !valid && !l.IsEnablePowMinning() {
-		l.StartPowMinning()
 		l.xlog.Debug("I have been interrupted from a remote node, because it has a higher block")
 		return nil, ErrMinerInterrupt
 	}

--- a/ledger/calc_nonce.go
+++ b/ledger/calc_nonce.go
@@ -13,7 +13,8 @@ func (l *Ledger) processFormatBlockForPOW(block *pb.InternalBlock, targetBits in
 	var gussCount int64
 	valid := false
 	var err error
-
+	// 在每次挖矿时，设置为true
+	l.StartPowMinning()
 	for {
 		if gussCount%round == 0 && !l.IsEnablePowMinning() {
 			break


### PR DESCRIPTION
## Description

What is the purpose of the change?
In order to make pow consensus do miner successfully, we should set the state of pow true because of The operation of SendBlock setting the state of pow false.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution
set the pow state true before do miner for pow

## How Has This Been Tested?

Regression Test
