### PR TITLE
add NewKVDB API to make code more readable and concise

### DIFF
--- a/kv/kvdb/kvdb_instance.go
+++ b/kv/kvdb/kvdb_instance.go
@@ -5,6 +5,7 @@ import (
 	"github.com/xuperchain/xuperunion/pluginmgr"
 )
 
+// KVParameter structure for kv instance parameters
 type KVParameter struct {
 	DBPath                string
 	KVEngineType          string
@@ -13,26 +14,32 @@ type KVParameter struct {
 	OtherPaths            []string
 }
 
+// GetDBPath return the value of DBPath
 func (param *KVParameter) GetDBPath() string {
 	return param.DBPath
 }
 
+// GetKVEngineType return the value of KVEngineType
 func (param *KVParameter) GetKVEngineType() string {
 	return param.KVEngineType
 }
 
+// GetMemCacheSize return the value of MemCacheSize
 func (param *KVParameter) GetMemCacheSize() int {
 	return param.MemCacheSize
 }
 
+// GetFileHandlersCacheSize return the value of FileHandlersCacheSize
 func (param *KVParameter) GetFileHandlersCacheSize() int {
 	return param.FileHandlersCacheSize
 }
 
+// GetOtherPaths return the value of OtherPaths
 func (param *KVParameter) GetOtherPaths() []string {
 	return param.OtherPaths
 }
 
+// NewKVDBInstance instance an object of kvdb
 func NewKVDBInstance(param *KVParameter) (Database, error) {
 	plgMgr, plgErr := pluginmgr.GetPluginMgr()
 	if plgErr != nil {

--- a/kv/kvdb/kvdb_instance.go
+++ b/kv/kvdb/kvdb_instance.go
@@ -1,0 +1,68 @@
+package kvdb
+
+import (
+	"path/filepath"
+
+	"github.com/xuperchain/xuperunion/common/log"
+	"github.com/xuperchain/xuperunion/pluginmgr"
+)
+
+type KVParameter struct {
+	StorePath             string
+	TableName             string
+	KvEngineType          string
+	MemCacheSize          int
+	FileHandlersCacheSize int
+	OtherPaths            []string
+}
+
+func (param *KVParameter) GetStorePath() string {
+	return param.StorePath
+}
+
+func (param *KVParameter) GetTableName() string {
+	return param.TableName
+}
+
+func (param *KVParameter) GetKvEngineType() string {
+	return param.KvEngineType
+}
+
+func (param *KVParameter) GetMemCacheSize() int {
+	return param.MemCacheSize
+}
+
+func (param *KVParameter) GetFileHandlersCacheSize() int {
+	return param.FileHandlersCacheSize
+}
+
+func (param *KVParameter) GetOtherPaths() []string {
+	return param.OtherPaths
+}
+
+func NewKVDBInstance(param *KVParameter) (Database, error) {
+	dbPath := filepath.Join(param.GetStorePath(), param.GetTableName())
+	plgMgr, plgErr := pluginmgr.GetPluginMgr()
+	if plgErr != nil {
+		log.Warn("fail to get plugin manager")
+		return nil, plgErr
+	}
+	var baseDB Database
+	soInst, err := plgMgr.PluginMgr.CreatePluginInstance("kv", param.GetKvEngineType())
+	if err != nil {
+		log.Warn("fail to create plugin instance", "kvtype", param.GetKvEngineType())
+		return nil, err
+	}
+	baseDB = soInst.(Database)
+	err = baseDB.Open(dbPath, map[string]interface{}{
+		"cache":     param.GetMemCacheSize(),
+		"fds":       param.GetFileHandlersCacheSize(),
+		"dataPaths": param.GetOtherPaths(),
+	})
+	if err != nil {
+		log.Warn("fail to open leveldb", "dbPath", dbPath, "err", err)
+		return nil, err
+	}
+
+	return baseDB, nil
+}

--- a/kv/kvdb/kvdb_instance.go
+++ b/kv/kvdb/kvdb_instance.go
@@ -1,31 +1,24 @@
 package kvdb
 
 import (
-	"path/filepath"
-
 	"github.com/xuperchain/xuperunion/common/log"
 	"github.com/xuperchain/xuperunion/pluginmgr"
 )
 
 type KVParameter struct {
-	StorePath             string
-	TableName             string
-	KvEngineType          string
+	DBPath                string
+	KVEngineType          string
 	MemCacheSize          int
 	FileHandlersCacheSize int
 	OtherPaths            []string
 }
 
-func (param *KVParameter) GetStorePath() string {
-	return param.StorePath
+func (param *KVParameter) GetDBPath() string {
+	return param.DBPath
 }
 
-func (param *KVParameter) GetTableName() string {
-	return param.TableName
-}
-
-func (param *KVParameter) GetKvEngineType() string {
-	return param.KvEngineType
+func (param *KVParameter) GetKVEngineType() string {
+	return param.KVEngineType
 }
 
 func (param *KVParameter) GetMemCacheSize() int {
@@ -41,26 +34,25 @@ func (param *KVParameter) GetOtherPaths() []string {
 }
 
 func NewKVDBInstance(param *KVParameter) (Database, error) {
-	dbPath := filepath.Join(param.GetStorePath(), param.GetTableName())
 	plgMgr, plgErr := pluginmgr.GetPluginMgr()
 	if plgErr != nil {
 		log.Warn("fail to get plugin manager")
 		return nil, plgErr
 	}
 	var baseDB Database
-	soInst, err := plgMgr.PluginMgr.CreatePluginInstance("kv", param.GetKvEngineType())
+	soInst, err := plgMgr.PluginMgr.CreatePluginInstance("kv", param.GetKVEngineType())
 	if err != nil {
-		log.Warn("fail to create plugin instance", "kvtype", param.GetKvEngineType())
+		log.Warn("fail to create plugin instance", "kvtype", param.GetKVEngineType())
 		return nil, err
 	}
 	baseDB = soInst.(Database)
-	err = baseDB.Open(dbPath, map[string]interface{}{
+	err = baseDB.Open(param.GetDBPath(), map[string]interface{}{
 		"cache":     param.GetMemCacheSize(),
 		"fds":       param.GetFileHandlersCacheSize(),
 		"dataPaths": param.GetOtherPaths(),
 	})
 	if err != nil {
-		log.Warn("fail to open leveldb", "dbPath", dbPath, "err", err)
+		log.Warn("fail to open leveldb", "dbPath", param.GetDBPath(), "err", err)
 		return nil, err
 	}
 

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sync"
 
@@ -95,16 +96,15 @@ func NewLedger(storePath string, xlog log.Logger, otherPaths []string, kvEngineT
 
 	// new kvdb instance
 	kvParam := &kvdb.KVParameter{
-		StorePath:             storePath,
-		TableName:             "ledger",
-		KvEngineType:          kvEngineType,
+		DBPath:                filepath.Join(storePath, "ledger"),
+		KVEngineType:          kvEngineType,
 		MemCacheSize:          MemCacheSize,
 		FileHandlersCacheSize: FileHandlersCacheSize,
 		OtherPaths:            otherPaths,
 	}
 	baseDB, err := kvdb.NewKVDBInstance(kvParam)
 	if err != nil {
-		xlog.Warn("fail to open leveldb", "dbPath", storePath+"ledger", "err", err)
+		xlog.Warn("fail to open leveldb", "dbPath", storePath+"/ledger", "err", err)
 		return nil, err
 	}
 

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"path/filepath"
 	"runtime"
 	"sync"
 
@@ -19,7 +18,6 @@ import (
 	"github.com/xuperchain/xuperunion/global"
 	"github.com/xuperchain/xuperunion/kv/kvdb"
 	"github.com/xuperchain/xuperunion/pb"
-	"github.com/xuperchain/xuperunion/pluginmgr"
 )
 
 var (
@@ -90,30 +88,23 @@ func NewLedger(storePath string, xlog log.Logger, otherPaths []string, kvEngineT
 	ledger := &Ledger{}
 	ledger.mutex = &sync.RWMutex{}
 	ledger.powMutex = &sync.Mutex{}
-	dbPath := filepath.Join(storePath, "ledger")
 	if xlog == nil { //如果外面没传进来log对象的话
 		xlog = log.New("module", "ledger")
 		xlog.SetHandler(log.StreamHandler(os.Stderr, log.LogfmtFormat()))
 	}
-	plgMgr, plgErr := pluginmgr.GetPluginMgr()
-	if plgErr != nil {
-		xlog.Warn("fail to get plugin manager")
-		return nil, plgErr
+
+	// new kvdb instance
+	kvParam := &kvdb.KVParameter{
+		StorePath:             storePath,
+		TableName:             "ledger",
+		KvEngineType:          kvEngineType,
+		MemCacheSize:          MemCacheSize,
+		FileHandlersCacheSize: FileHandlersCacheSize,
+		OtherPaths:            otherPaths,
 	}
-	var baseDB kvdb.Database
-	soInst, err := plgMgr.PluginMgr.CreatePluginInstance("kv", kvEngineType)
+	baseDB, err := kvdb.NewKVDBInstance(kvParam)
 	if err != nil {
-		xlog.Warn("fail to create plugin instance", "kvtype", kvEngineType)
-		return nil, err
-	}
-	baseDB = soInst.(kvdb.Database)
-	err = baseDB.Open(dbPath, map[string]interface{}{
-		"cache":     MemCacheSize,
-		"fds":       FileHandlersCacheSize,
-		"dataPaths": otherPaths,
-	})
-	if err != nil {
-		xlog.Warn("fail to open db", "db_path", dbPath)
+		xlog.Warn("fail to open leveldb", "dbPath", storePath+"ledger", "err", err)
 		return nil, err
 	}
 

--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -333,16 +334,15 @@ func MakeUtxoVM(bcname string, ledger *ledger_pkg.Ledger, storePath string, priv
 	}
 	// new kvdb instance
 	kvParam := &kvdb.KVParameter{
-		StorePath:             storePath,
-		TableName:             "utxoVM",
-		KvEngineType:          kvEngineType,
+		DBPath:                filepath.Join(storePath, "utxoVM"),
+		KVEngineType:          kvEngineType,
 		MemCacheSize:          ledger_pkg.MemCacheSize,
 		FileHandlersCacheSize: ledger_pkg.FileHandlersCacheSize,
 		OtherPaths:            otherPaths,
 	}
 	baseDB, err := kvdb.NewKVDBInstance(kvParam)
 	if err != nil {
-		xlog.Warn("fail to open leveldb", "dbPath", storePath+"utxoVM", "err", err)
+		xlog.Warn("fail to open leveldb", "dbPath", storePath+"/utxoVM", "err", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
## Description

What is the purpose of the change?
The API of NewKVDatabase is a common API, many modules may invoke it, and we should support it as a basic API to make code readable.

Fixes #351 

## Type of change

- [x] Improvement

## Brief of your solution

Support an API implementing the NewKVDatabase on the module of kv/kvdb

## How Has This Been Tested?

Regression Test
