### PR TITLE
xvm: fix panic when deploying new contract code

### DIFF
--- a/contract/wasm/vm/xvm/code_manager.go
+++ b/contract/wasm/vm/xvm/code_manager.go
@@ -3,6 +3,7 @@ package xvm
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -65,6 +66,10 @@ func (c *codeManager) purgeMemCache(name string) {
 }
 
 func (c *codeManager) makeMemCache(name, libpath string, desc *pb.WasmCodeDesc) (*contractCode, error) {
+	if _, ok := c.codes[name]; ok {
+		return nil, errors.New("old contract code not purged")
+	}
+
 	execCode, err := c.makeExecCode(libpath)
 	if err != nil {
 		return nil, err
@@ -73,9 +78,6 @@ func (c *codeManager) makeMemCache(name, libpath string, desc *pb.WasmCodeDesc) 
 		ContractName: name,
 		ExecCode:     execCode,
 		Desc:         *desc,
-	}
-	if old, ok := c.codes[name]; ok {
-		old.ExecCode.Release()
 	}
 	c.codes[name] = code
 


### PR DESCRIPTION
If the deployment of the contract fails with some error and not due to the contract itself, in order to speed up the execution of the contract, the cache of the contract is saved at this time. After deploying again, a new contract code is used. Since the previous contract handle is not cleaned up, dlopen will use the previous dlhandle, and since the old so file is overwritten, the kernel will reclaim the memory space of the previous so file mmap. As a result, the new dlhandle has a memory error when calling dlsym.

fix #352 
