### PR TITLE
p2p: persist Routing Table

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -29,7 +29,7 @@ const (
 	DefaultMaxBroadcastPeers     = 20
 	DefaultMaxBroadcastCorePeers = 10
 	DefaultIsStorePeers          = false
-	DefaultP2PDataPath           = "./data/"
+	DefaultP2PDataPath           = "./data/p2p"
 )
 
 // LogConfig is the log config of node

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -28,6 +28,8 @@ const (
 	DefaultStreamIPLimitSize     = 10
 	DefaultMaxBroadcastPeers     = 20
 	DefaultMaxBroadcastCorePeers = 10
+	DefaultIsStorePeers          = false
+	DefaultP2PDataPath           = "./data/"
 )
 
 // LogConfig is the log config of node
@@ -93,6 +95,10 @@ type P2PConfig struct {
 	// this only works when NodeConfig.CoreConnection is true. Note that the number
 	// of core peers is included in MaxBroadcastPeers.
 	MaxBroadcastCorePeers int `yaml:"maxBroadcastCorePeers,omitempty"`
+	// P2PDataPath stores the peer info connected last time
+	P2PDataPath string `yaml:"p2PDataPath,omitempty"`
+	// IsStorePeers determine wherther storing the peers infos
+	IsStorePeers bool `yaml:"isStorePeers,omitempty"`
 }
 
 // MinerConfig is the config of miner
@@ -310,6 +316,8 @@ func newP2pConfigWithDefault() P2PConfig {
 		StreamIPLimitSize:     DefaultStreamIPLimitSize,
 		MaxBroadcastPeers:     DefaultMaxBroadcastPeers,
 		MaxBroadcastCorePeers: DefaultMaxBroadcastCorePeers,
+		IsStorePeers:          DefaultIsStorePeers,
+		P2PDataPath:           DefaultP2PDataPath,
 	}
 }
 

--- a/p2pv2/node.go
+++ b/p2pv2/node.go
@@ -117,7 +117,7 @@ func NewNode(cfg config.P2PConfig, log log.Logger) (*Node, error) {
 		p2pDataPath:  cfg.P2PDataPath,
 	}
 	if no.isStorePeers {
-		no.ldb, err = newBaseDB("./p2p")
+		no.ldb, err = newBaseDB(no.p2pDataPath)
 		if err != nil {
 			return nil, err
 		}

--- a/p2pv2/node.go
+++ b/p2pv2/node.go
@@ -145,16 +145,9 @@ func NewNode(cfg config.P2PConfig, log log.Logger) (*Node, error) {
 		}
 	}
 
-	// connect to bootNodes
-	/*
-		succNum := no.connectToPeersByAddr(cfg.BootNodes)
-		if len(cfg.BootNodes) != 0 && succNum == 0 {
-			return nil, ErrConnectBootStrap
-		}
-	*/
-	peers := []string{}
-	// connect to bootNodes
 	// connect to peers stored last time recently
+	// connect to bootNodes
+	peers := []string{}
 	if no.isStorePeers {
 		peers, err = no.getPeersFromDisk()
 		if err != nil {

--- a/p2pv2/node.go
+++ b/p2pv2/node.go
@@ -6,6 +6,8 @@ import (
 	"math/rand"
 	"sync"
 	"time"
+	//"path/filepath"
+	"strings"
 
 	iaddr "github.com/ipfs/go-ipfs-addr"
 	"github.com/libp2p/go-libp2p"
@@ -22,11 +24,14 @@ import (
 
 	"github.com/xuperchain/xuperunion/common/config"
 	p2pPb "github.com/xuperchain/xuperunion/p2pv2/pb"
+
+	"github.com/xuperchain/xuperunion/kv/kvdb"
 )
 
 // define the common config
 const (
-	XuperProtocolID = "/xuper/2.0.0" // protocol version
+	XuperProtocolID    = "/xuper/2.0.0" // protocol version
+	P2PMultiAddrPrefix = "p2pMulti_"
 )
 
 var (
@@ -46,6 +51,7 @@ var (
 	ErrConnectBootStrap = errors.New("error to connect to all bootstrap")
 	ErrConnectCorePeers = errors.New("error to connect to all core peers")
 	ErrInvalidParams    = errors.New("invalid params")
+	ErrGetPeersFromDisk = errors.New("get peers from disk error")
 )
 
 type corePeerInfo struct {
@@ -76,6 +82,11 @@ type Node struct {
 	routeLock sync.RWMutex
 	// StreamLimit
 	streamLimit *StreamLimit
+	// ldb persist peers info and get peers info
+	ldb kvdb.Database
+	// isStorePeers determine whether open isStorePeers
+	isStorePeers bool
+	p2pDataPath  string
 }
 
 // NewNode define the node of the xuper, it will set streamHandler for this node.
@@ -101,7 +112,15 @@ func NewNode(cfg config.P2PConfig, log log.Logger) (*Node, error) {
 		addrs:     map[string]*XchainAddrInfo{},
 		coreRoute: make(map[string]*corePeersRoute),
 		// new StreamLimit
-		streamLimit: &StreamLimit{},
+		streamLimit:  &StreamLimit{},
+		isStorePeers: cfg.IsStorePeers,
+		p2pDataPath:  cfg.P2PDataPath,
+	}
+	if no.isStorePeers {
+		no.ldb, err = newBaseDB("./p2p")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// set broadcast peers limitation
@@ -127,8 +146,26 @@ func NewNode(cfg config.P2PConfig, log log.Logger) (*Node, error) {
 	}
 
 	// connect to bootNodes
-	succNum := no.connectToPeersByAddr(cfg.BootNodes)
-	if len(cfg.BootNodes) != 0 && succNum == 0 {
+	/*
+		succNum := no.connectToPeersByAddr(cfg.BootNodes)
+		if len(cfg.BootNodes) != 0 && succNum == 0 {
+			return nil, ErrConnectBootStrap
+		}
+	*/
+	peers := []string{}
+	// connect to bootNodes
+	// connect to peers stored last time recently
+	if no.isStorePeers {
+		peers, err = no.getPeersFromDisk()
+		if err != nil {
+			return nil, ErrGetPeersFromDisk
+		}
+	}
+	if len(cfg.BootNodes) > 0 {
+		peers = append(peers, cfg.BootNodes...)
+	}
+	succNum := no.connectToPeersByAddr(peers)
+	if succNum == 0 && len(cfg.BootNodes) != 0 {
 		return nil, ErrConnectBootStrap
 	}
 	return no, nil
@@ -168,6 +205,9 @@ func (no *Node) Start() {
 		case <-t.C:
 			no.log.Trace("RoutingTable", "size", no.kdht.RoutingTable().Size())
 			no.kdht.RoutingTable().Print()
+			if no.isStorePeers {
+				no.persistPeersToDisk()
+			}
 		}
 	}
 }
@@ -414,4 +454,60 @@ func (no *Node) createPeerStream(ppi []*pstore.PeerInfo) int {
 		}
 	}
 	return succNum
+}
+
+// persistPeersToDisk persist peers connecting to each other to disk
+func (no *Node) persistPeersToDisk() bool {
+	batch := no.ldb.NewBatch()
+	prefix := no.GetP2PMultiAddrPrefix()
+	it := no.ldb.NewIteratorWithPrefix([]byte(prefix))
+	defer it.Release()
+	// delete history records before
+	for it.Next() {
+		batch.Delete(it.Key())
+	}
+	if it.Error() != nil {
+		return false
+	}
+	peers := no.streamLimit.GetStreams()
+	// persist recent records after
+	for _, peer := range peers {
+		batch.Put([]byte(prefix+peer), []byte("true"))
+	}
+	batch.Write()
+	return true
+}
+
+// getPeersFromDisk get peers from disk
+func (no *Node) getPeersFromDisk() ([]string, error) {
+	peers := []string{}
+	prefix := no.GetP2PMultiAddrPrefix()
+	it := no.ldb.NewIteratorWithPrefix([]byte(prefix))
+	defer it.Release()
+	for it.Next() {
+		key := string(it.Key())
+		key = strings.TrimPrefix(key, prefix)
+		peers = append(peers, key)
+	}
+	if it.Error() != nil {
+		return nil, it.Error()
+	}
+	return peers, nil
+}
+
+func newBaseDB(dbPath string) (kvdb.Database, error) {
+	// new kv instance
+	kvParam := &kvdb.KVParameter{
+		DBPath:                dbPath,
+		KVEngineType:          "default",
+		MemCacheSize:          128,
+		FileHandlersCacheSize: 512,
+		OtherPaths:            []string{},
+	}
+	return kvdb.NewKVDBInstance(kvParam)
+}
+
+// GetP2PMultiAddrPrefix return P2PMultiAddrPrefix
+func (no *Node) GetP2PMultiAddrPrefix() string {
+	return P2PMultiAddrPrefix
 }

--- a/p2pv2/node.go
+++ b/p2pv2/node.go
@@ -199,7 +199,10 @@ func (no *Node) Start() {
 			no.log.Trace("RoutingTable", "size", no.kdht.RoutingTable().Size())
 			no.kdht.RoutingTable().Print()
 			if no.isStorePeers {
-				no.persistPeersToDisk()
+				ret := no.persistPeersToDisk()
+				if !ret {
+					log.Warn("persistPeersToDisk failed")
+				}
 			}
 		}
 	}
@@ -467,7 +470,11 @@ func (no *Node) persistPeersToDisk() bool {
 	for _, peer := range peers {
 		batch.Put([]byte(prefix+peer), []byte("true"))
 	}
-	batch.Write()
+	writeErr := batch.Write()
+	if writeErr != nil {
+		log.Warn("p2p module, persistPeersToDisk error", "err", writeErr)
+		return false
+	}
 	return true
 }
 

--- a/p2pv2/node.go
+++ b/p2pv2/node.go
@@ -151,7 +151,7 @@ func NewNode(cfg config.P2PConfig, log log.Logger) (*Node, error) {
 	if no.isStorePeers {
 		peers, err = no.getPeersFromDisk()
 		if err != nil {
-			return nil, ErrGetPeersFromDisk
+			no.log.Warn("getPeersFromDisk error", "err", err)
 		}
 	}
 	if len(cfg.BootNodes) > 0 {

--- a/p2pv2/node.go
+++ b/p2pv2/node.go
@@ -51,7 +51,6 @@ var (
 	ErrConnectBootStrap = errors.New("error to connect to all bootstrap")
 	ErrConnectCorePeers = errors.New("error to connect to all core peers")
 	ErrInvalidParams    = errors.New("invalid params")
-	ErrGetPeersFromDisk = errors.New("get peers from disk error")
 )
 
 type corePeerInfo struct {

--- a/p2pv2/stream_limit.go
+++ b/p2pv2/stream_limit.go
@@ -113,3 +113,18 @@ func (sl *StreamLimit) nearFull(ip string) bool {
 	defer sl.mutex.Unlock()
 	return sl.ip2cnt[ip] >= sl.limit
 }
+
+// GetStreams get all NetURLs from effective streams
+func (sl *StreamLimit) GetStreams() []string {
+	peers := []string{}
+	sl.streams.Range(func(key, value interface{}) bool {
+		peer := sl.makeNetURL(key.(string), value.(peer.ID))
+		peers = append(peers, peer)
+		return true
+	})
+	return peers
+}
+
+func (sl *StreamLimit) makeNetURL(key string, peerID peer.ID) string {
+	return key + "/p2p/" + string(peerID.Pretty())
+}


### PR DESCRIPTION
## Description

What is the purpose of the change?
When you reboot your node, you can still get a quicker connection to the network of blockchain system even though the bootstrap is not available which makes the network healthier.

Fixes #354 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Brief of your solution

Persist the healthy peers periodically

## How Has This Been Tested?

Regression Test