### PR TITLE
doc: Add the command to enter the output folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ make test
 
 单机版xchain
 ```
+cd output
 ./xchain-cli createChain
 nohup ./xchain &
 ./xchain-cli status


### PR DESCRIPTION
 In Chinese document, no mention of entering the output folder before run `xchain-cli`