### PR TITLE
ignore 0 amount for output

### DIFF
--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -1077,13 +1077,14 @@ func (uv *UtxoVM) undoTxInternal(tx *pb.Transaction, batch kvdb.Batch) error {
 		if bytes.Equal(addr, []byte(FeePlaceholder)) {
 			continue
 		}
-		if big.NewInt(0).SetBytes(txOutput.Amount).Cmp(big.NewInt(0)) == 0 {
+		txOutputAmount := big.NewInt(0).SetBytes(txOutput.Amount)
+		if txOutputAmount.Cmp(big.NewInt(0)) == 0 {
 			continue
 		}
 		utxoKey := GenUtxoKeyWithPrefix(addr, tx.Txid, int32(offset))
 		batch.Delete([]byte(utxoKey)) // 删除产生的UTXO
 		uv.utxoCache.Remove(string(addr), utxoKey)
-		uv.subBalance(addr, big.NewInt(0).SetBytes(txOutput.Amount))
+		uv.subBalance(addr, txOutputAmount)
 		uv.xlog.Trace("    undo delete utxo key", "utxoKey", utxoKey)
 		if tx.Coinbase {
 			// coinbase交易（包括创始块和挖矿奖励), 回滚会导致系统总资产缩水

--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -945,18 +945,15 @@ func (uv *UtxoVM) payFee(tx *pb.Transaction, batch kvdb.Batch, block *pb.Interna
 		if !bytes.Equal(addr, []byte(FeePlaceholder)) {
 			continue
 		}
+		addr = block.Proposer // 占位符替换为矿工
+		utxoKey := GenUtxoKeyWithPrefix(addr, tx.Txid, int32(offset))
 		uItem := &UtxoItem{}
 		uItem.Amount = big.NewInt(0)
 		uItem.Amount.SetBytes(txOutput.Amount)
-		if uItem.Amount.Cmp(big.NewInt(0)) == 0 {
-			continue
-		}
 		uItemBinary, uErr := uItem.Dumps()
 		if uErr != nil {
 			return uErr
 		}
-		addr = block.Proposer // 占位符替换为矿工
-		utxoKey := GenUtxoKeyWithPrefix(addr, tx.Txid, int32(offset))
 		batch.Put([]byte(utxoKey), uItemBinary) // 插入本交易产生的utxo
 		uv.addBalance(addr, uItem.Amount)
 		uv.utxoCache.Insert(string(addr), utxoKey, uItem)
@@ -970,9 +967,6 @@ func (uv *UtxoVM) undoPayFee(tx *pb.Transaction, batch kvdb.Batch, block *pb.Int
 	for offset, txOutput := range tx.TxOutputs {
 		addr := txOutput.ToAddr
 		if !bytes.Equal(addr, []byte(FeePlaceholder)) {
-			continue
-		}
-		if txOutput.Amount.Cmp(big.NewInt(0)) == 0 {
 			continue
 		}
 		addr = block.Proposer

--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -1077,7 +1077,7 @@ func (uv *UtxoVM) undoTxInternal(tx *pb.Transaction, batch kvdb.Batch) error {
 		if bytes.Equal(addr, []byte(FeePlaceholder)) {
 			continue
 		}
-		if txOutput.Amount.Cmp(big.NewInt(0)) == 0 {
+		if big.NewInt(0).SetBytes(txOutput.Amount).Cmp(big.NewInt(0)) == 0 {
 			continue
 		}
 		utxoKey := GenUtxoKeyWithPrefix(addr, tx.Txid, int32(offset))

--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -1077,6 +1077,9 @@ func (uv *UtxoVM) undoTxInternal(tx *pb.Transaction, batch kvdb.Batch) error {
 		if bytes.Equal(addr, []byte(FeePlaceholder)) {
 			continue
 		}
+		if txOutput.Amount.Cmp(big.NewInt(0)) == 0 {
+			continue
+		}
 		utxoKey := GenUtxoKeyWithPrefix(addr, tx.Txid, int32(offset))
 		batch.Delete([]byte(utxoKey)) // 删除产生的UTXO
 		uv.utxoCache.Remove(string(addr), utxoKey)


### PR DESCRIPTION
## Description

What is the purpose of the change?
When the award amount is 0, it is a better way to ignore it when put utxo into leveldb which economizing some disk and speeding up the process of query.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [ ] Improvement

## Brief of your solution

Please describe your solution to solve the issue or feature request.
Ignore 0 amount for output

## How Has This Been Tested?

Regression Test
