### PR TITLE
Clear the meaning of initiator

### DIFF
--- a/utxo/tx_verification.go
+++ b/utxo/tx_verification.go
@@ -167,7 +167,6 @@ func (uv *UtxoVM) verifySignatures(tx *pb.Transaction, digestHash []byte) (bool,
 			verifiedAddr[addr] = true
 			initiatorAddr = append(initiatorAddr, tx.Initiator+"/"+addr)
 		}
-		// check initator ACL here, this part should be removed after initiator is address.
 		ok, err := pm.IdentifyAccount(tx.Initiator, initiatorAddr, uv.aclMgr)
 		if !ok {
 			uv.xlog.Warn("verifySignatures initiator permission check failed",

--- a/utxo/tx_verification.go
+++ b/utxo/tx_verification.go
@@ -66,11 +66,6 @@ func (uv *UtxoVM) ImmediateVerifyTx(tx *pb.Transaction, isRootTx bool) (bool, er
 			return false, fmt.Errorf("Txid verify failed")
 		}
 
-		// verify initiator type
-		if akType := acl.IsAccount(tx.Initiator); akType != 0 {
-			return false, ErrInitiatorType
-		}
-
 		// get digestHash
 		digestHash, err := txhash.MakeTxDigestHash(tx)
 		if err != nil {
@@ -141,13 +136,48 @@ func (uv *UtxoVM) verifySignatures(tx *pb.Transaction, digestHash []byte) (bool,
 	}
 
 	// verify initiator
-	// check initiator address signature, initiator could only be address after verify initiator type check
-	ok, err := pm.IdentifyAK(tx.Initiator, tx.InitiatorSigns[0], digestHash)
-	if err != nil || !ok {
-		uv.xlog.Warn("verifySignatures failed", "address", tx.Initiator, "error", err)
-		return false, nil, err
+	akType := acl.IsAccount(tx.Initiator)
+	if akType == 0 {
+		// check initiator address signature
+		ok, err := pm.IdentifyAK(tx.Initiator, tx.InitiatorSigns[0], digestHash)
+		if err != nil || !ok {
+			uv.xlog.Warn("verifySignatures failed", "address", tx.Initiator, "error", err)
+			return false, nil, err
+		}
+		verifiedAddr[tx.Initiator] = true
+	} else if akType == 1 {
+		initiatorAddr := make([]string, 0)
+		// check initiator account signatures
+		for _, sign := range tx.InitiatorSigns {
+			ak, err := uv.cryptoClient.GetEcdsaPublicKeyFromJSON([]byte(sign.PublicKey))
+			if err != nil {
+				uv.xlog.Warn("verifySignatures failed", "address", tx.Initiator, "error", err)
+				return false, nil, err
+			}
+			addr, err := uv.cryptoClient.GetAddressFromPublicKey(ak)
+			if err != nil {
+				uv.xlog.Warn("verifySignatures failed", "address", tx.Initiator, "error", err)
+				return false, nil, err
+			}
+			ok, err := pm.IdentifyAK(addr, sign, digestHash)
+			if !ok {
+				uv.xlog.Warn("verifySignatures failed", "address", tx.Initiator, "error", err)
+				return ok, nil, err
+			}
+			verifiedAddr[addr] = true
+			initiatorAddr = append(initiatorAddr, tx.Initiator+"/"+addr)
+		}
+		// check initator ACL here, this part should be removed after initiator is address.
+		ok, err := pm.IdentifyAccount(tx.Initiator, initiatorAddr, uv.aclMgr)
+		if !ok {
+			uv.xlog.Warn("verifySignatures initiator permission check failed",
+				"account", tx.Initiator, "error", err)
+			return false, nil, err
+		}
+	} else {
+		uv.xlog.Warn("verifySignatures failed, invalid address", "address", tx.Initiator)
+		return false, nil, ErrInvalidSignature
 	}
-	verifiedAddr[tx.GetInitiator()] = true
 
 	// verify authRequire
 	for idx, authReq := range tx.AuthRequire {

--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -66,7 +66,6 @@ var (
 	ErrRWSetInvalid            = errors.New("RWSet of transaction invalid")
 	ErrACLNotEnough            = errors.New("ACL not enough")
 	ErrInvalidSignature        = errors.New("the signature is invalid or not match the address")
-	ErrInitiatorType           = errors.New("the initiator type is invalid, need AK")
 
 	ErrGasNotEnough   = errors.New("Gas not enough")
 	ErrInvalidAccount = errors.New("Invalid account")
@@ -702,11 +701,6 @@ func (uv *UtxoVM) SelectUtxos(fromAddr string, fromPubKey string, totalNeed *big
 
 // PreExec the Xuper3 contract model uses previous execution to generate RWSets
 func (uv *UtxoVM) PreExec(req *pb.InvokeRPCRequest, hd *global.XContext) (*pb.InvokeResponse, error) {
-	// verify initiator type
-	if akType := acl.IsAccount(req.GetInitiator()); akType != 0 {
-		return nil, ErrInitiatorType
-	}
-
 	// get reserved contracts from chain config
 	reservedRequests, err := uv.getReservedContractRequests(req.GetRequests(), true)
 	if err != nil {


### PR DESCRIPTION
## Description

Currently, the initiator of transaction can only be address and the meaning of initiator is vague.
It's not convenient for using while invoke a contract.
It's better to clear the meaning of initiator.

- The initiator can be both address and account.
- The caller of a contract is initiator.

Fixes #403 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Brief of your solution

Please describe your solution to solve the issue or feature request.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
