### PR TITLE
use block's height associated with proposal's context

### DIFF
--- a/contract/proposal/proposal.go
+++ b/contract/proposal/proposal.go
@@ -56,7 +56,7 @@ func (prp *Proposal) Run(desc *contract.TxDesc) error {
 	case proposeMethod:
 		return prp.runPropose(desc)
 	case voteMethod:
-		return prp.runVote(desc)
+		return prp.runVote(desc, prp.context.Block)
 	case createTriggerMethod:
 		return prp.saveTrigger(desc.Tx.Txid, desc.Trigger)
 	case thawMethod:
@@ -201,7 +201,7 @@ func (prp *Proposal) IsPropose(proposalTx *pb.Transaction) bool {
 	return proposalDesc.Method == proposeMethod
 }
 
-func (prp *Proposal) runVote(desc *contract.TxDesc) error {
+func (prp *Proposal) runVote(desc *contract.TxDesc, block *pb.InternalBlock) error {
 	prp.log.Debug("start run vote")
 	proposalTxid, err := prp.getTxidFromArgs(desc)
 	if err != nil {
@@ -220,7 +220,8 @@ func (prp *Proposal) runVote(desc *contract.TxDesc) error {
 		return err
 	}
 	stopVoteHeight := int64(argValue)
-	ledgerHeight := prp.ledger.GetMeta().TrunkHeight
+	//ledgerHeight := prp.ledger.GetMeta().TrunkHeight
+	ledgerHeight := block.Height
 	if ledgerHeight > stopVoteHeight {
 		prp.log.Warn(fmt.Sprintf("this propposal is expired for voting, %d > %d", ledgerHeight, stopVoteHeight))
 		return nil

--- a/core/xchaincore.go
+++ b/core/xchaincore.go
@@ -617,7 +617,7 @@ func (xc *XChainCore) doMiner() {
 		txs = append(txs, ucTx)
 	}
 	fakeBlock, err := xc.Ledger.FormatFakeBlock(txs, xc.address, xc.privateKey,
-		t.UnixNano(), curTerm, curBlockNum, xc.Utxovm.GetLatestBlockid(), xc.Utxovm.GetTotal())
+		t.UnixNano(), curTerm, curBlockNum, xc.Utxovm.GetLatestBlockid(), xc.Utxovm.GetTotal(), xc.Ledger.GetMeta().TrunkHeight+1)
 	if err != nil {
 		xc.log.Warn("[Minning] format fake block error", "logid")
 		return
@@ -638,7 +638,7 @@ func (xc *XChainCore) doMiner() {
 	txs = append(txs, awardtx)
 	freshBlock, err = xc.Ledger.FormatMinerBlock(txs, xc.address, xc.privateKey,
 		t.UnixNano(), curTerm, curBlockNum, xc.Utxovm.GetLatestBlockid(), targetBits,
-		xc.Utxovm.GetTotal(), qc, fakeBlock.FailedTxs)
+		xc.Utxovm.GetTotal(), qc, fakeBlock.FailedTxs, xc.Ledger.GetMeta().TrunkHeight+1)
 	if err != nil {
 		xc.log.Warn("[Minning] format block error", "logid", header.Logid, "err", err)
 		return

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -220,7 +220,7 @@ func (l *Ledger) FormatBlock(txList []*pb.Transaction,
 	proposer []byte, ecdsaPk *ecdsa.PrivateKey, /*矿工的公钥私钥*/
 	timestamp int64, curTerm int64, curBlockNum int64,
 	preHash []byte, utxoTotal *big.Int) (*pb.InternalBlock, error) {
-	return l.formatBlock(txList, proposer, ecdsaPk, timestamp, curTerm, curBlockNum, preHash, 0, utxoTotal, true, nil, nil)
+	return l.formatBlock(txList, proposer, ecdsaPk, timestamp, curTerm, curBlockNum, preHash, 0, utxoTotal, true, nil, nil, 0)
 }
 
 // FormatMinerBlock format block for miner
@@ -228,8 +228,8 @@ func (l *Ledger) FormatMinerBlock(txList []*pb.Transaction,
 	proposer []byte, ecdsaPk *ecdsa.PrivateKey, /*矿工的公钥私钥*/
 	timestamp int64, curTerm int64, curBlockNum int64,
 	preHash []byte, targetBits int32, utxoTotal *big.Int,
-	qc *pb.QuorumCert, failedTxs map[string]string) (*pb.InternalBlock, error) {
-	return l.formatBlock(txList, proposer, ecdsaPk, timestamp, curTerm, curBlockNum, preHash, targetBits, utxoTotal, true, qc, failedTxs)
+	qc *pb.QuorumCert, failedTxs map[string]string, blockHeight int64) (*pb.InternalBlock, error) {
+	return l.formatBlock(txList, proposer, ecdsaPk, timestamp, curTerm, curBlockNum, preHash, targetBits, utxoTotal, true, qc, failedTxs, blockHeight)
 }
 
 // IsProofed check workload proof
@@ -248,8 +248,8 @@ func IsProofed(blockID []byte, targetBits int32) bool {
 func (l *Ledger) FormatFakeBlock(txList []*pb.Transaction,
 	proposer []byte, ecdsaPk *ecdsa.PrivateKey, /*矿工的公钥私钥*/
 	timestamp int64, curTerm int64, curBlockNum int64,
-	preHash []byte, utxoTotal *big.Int) (*pb.InternalBlock, error) {
-	return l.formatBlock(txList, proposer, ecdsaPk, timestamp, curTerm, curBlockNum, preHash, 0, utxoTotal, false, nil, nil)
+	preHash []byte, utxoTotal *big.Int, blockHeight int64) (*pb.InternalBlock, error) {
+	return l.formatBlock(txList, proposer, ecdsaPk, timestamp, curTerm, curBlockNum, preHash, 0, utxoTotal, false, nil, nil, blockHeight)
 }
 
 /*
@@ -259,7 +259,7 @@ func (l *Ledger) formatBlock(txList []*pb.Transaction,
 	proposer []byte, ecdsaPk *ecdsa.PrivateKey, /*矿工的公钥私钥*/
 	timestamp int64, curTerm int64, curBlockNum int64,
 	preHash []byte, targetBits int32, utxoTotal *big.Int, needSign bool,
-	qc *pb.QuorumCert, failedTxs map[string]string) (*pb.InternalBlock, error) {
+	qc *pb.QuorumCert, failedTxs map[string]string, blockHeight int64) (*pb.InternalBlock, error) {
 	l.xlog.Info("begin format block", "preHash", fmt.Sprintf("%x", preHash))
 	//编译的环境变量指定
 	block := &pb.InternalBlock{Version: BlockVersion}
@@ -271,6 +271,7 @@ func (l *Ledger) formatBlock(txList []*pb.Transaction,
 	block.CurBlockNum = curBlockNum
 	block.TargetBits = targetBits
 	block.Justify = qc
+	block.Height = blockHeight
 	jsPk, pkErr := l.cryptoClient.GetEcdsaPublicKeyJSONFormat(ecdsaPk)
 	if pkErr != nil {
 		return nil, pkErr


### PR DESCRIPTION
## Description

What is the purpose of the change?

Fix the problem the miner gets the vat in a lower height than the validation nodes.

Fixes #435 

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution

Use block's height associated with proposal's context instead of ledger.GetMeta().TrunkHeight.

