### PR TITLE
Add interface to get addresses belongs to account

### DIFF
--- a/permission/acl/acl_manager.go
+++ b/permission/acl/acl_manager.go
@@ -8,6 +8,7 @@ import (
 type AccountACL interface {
 	GetAccountACL(accountName string) (*pb.Acl, error)
 	GetAccountACLWithConfirmed(accountName string) (*pb.Acl, bool, error)
+	GetAccountAddresses(accountName string) ([]string, error)
 }
 
 // ContractACL is interface to read/write contracts' ACL

--- a/permission/acl/impl/manager_test.go
+++ b/permission/acl/impl/manager_test.go
@@ -1,0 +1,83 @@
+package impl
+
+import (
+	"testing"
+
+	"github.com/xuperchain/xuperunion/pb"
+)
+
+func Test_GetAccountAddressesWithThreshold(t *testing.T) {
+	aclMgr, err := NewACLManager(nil)
+	if err != nil {
+		t.Error("NewAclManager failed, err=", err)
+		return
+	}
+
+	// test threshold model
+	pm := &pb.PermissionModel{
+		Rule:        pb.PermissionRule_SIGN_THRESHOLD,
+		AcceptValue: 1,
+	}
+	aclObj := &pb.Acl{
+		Pm:        pm,
+		AksWeight: make(map[string]float64),
+	}
+
+	aclObj.AksWeight["dpzuVdosQrF2kmzumhVeFQZa1aYcdgFpN"] = 0.5
+	aclObj.AksWeight["WNWk3ekXeM5M2232dY2uCJmEqWhfQiDYT"] = 0.5
+
+	addresses, err := aclMgr.getAddressesByACL(aclObj)
+	if err != nil {
+		t.Error("get addresses failed, err=", err)
+		return
+	}
+	if len(addresses) != 2 {
+		t.Error("get addresses failed, invalid addresses length, len=", len(addresses))
+		return
+	}
+	t.Log("addresses in ACL are:", addresses)
+}
+
+func Test_GetAccountAddressesWithAKSet(t *testing.T) {
+	aclMgr, err := NewACLManager(nil)
+	if err != nil {
+		t.Error("NewAclManager failed, err=", err)
+		return
+	}
+
+	// test ak set
+	pm := &pb.PermissionModel{
+		Rule:        pb.PermissionRule_SIGN_AKSET,
+		AcceptValue: 1,
+	}
+	aksets := &pb.AkSets{
+		Sets:       make(map[string]*pb.AkSet),
+		Expression: "",
+	}
+	aclObj := &pb.Acl{
+		Pm:     pm,
+		AkSets: aksets,
+	}
+	set1 := &pb.AkSet{
+		Aks: []string{"ak1", "ak2"},
+	}
+
+	set2 := &pb.AkSet{
+		Aks: []string{"ak3"},
+	}
+
+	aclObj.AkSets.Sets["1"] = set1
+	aclObj.AkSets.Sets["2"] = set2
+
+	addresses, err := aclMgr.getAddressesByACL(aclObj)
+	if err != nil {
+		t.Error("get addresses failed, err=", err)
+		return
+	}
+	if len(addresses) != 3 {
+		t.Error("get addresses failed, invalid addresses length, len=", len(addresses))
+		return
+	}
+	t.Log("addresses in ACL are:", addresses)
+
+}

--- a/permission/acl/mock/fake_mgr.go
+++ b/permission/acl/mock/fake_mgr.go
@@ -51,3 +51,8 @@ func (fm *FakeACLManager) GetContractMethodACL(contractName string, methodName s
 func (fm *FakeACLManager) GetContractMethodACLWithConfirmed(contractName string, methodName string) (*pb.Acl, bool, error) {
 	return nil, true, nil
 }
+
+// GetAccountAddresses not used in this mockup
+func (fm *FakeACLManager) GetAccountAddresses(accountName string) ([]string, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## Description

Add interface in ACLManager to get addresses belongs to account

Fixes #443 

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Brief of your solution

Implement the interface in each permission rule model, and expose in ACLManager.

```
GetAccountAddresses(accountName string) ([]string, error)
```

This function return all addresses in the ACL config of `accountName`.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
