### PR TITLE
fix reserved contract name in contract status interface

### DIFF
--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -2203,8 +2203,8 @@ func (uv *UtxoVM) GetContractStatus(contractName string) (*pb.ContractStatus, er
 func (uv *UtxoVM) queryContractBannedStatus(contractName string) (bool, error) {
 	request := &pb.InvokeRequest{
 		ModuleName:   "wasm",
-		ContractName: "banned",
-		MethodName:   "verify",
+		ContractName: "unified_check",
+		MethodName:   "banned_check",
 		Args: map[string][]byte{
 			"contract": []byte(contractName),
 		},


### PR DESCRIPTION
## Description

From V3.4, we use unified_check as reserved contract. So when we get contract status, should replace banned with unified_check.

Fixes #451 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution

Please describe your solution to solve the issue or feature request.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
