### PR TITLE
xmodel: reduce initial memory size of model cache

### DIFF
--- a/xmodel/env.go
+++ b/xmodel/env.go
@@ -40,10 +40,6 @@ func (s *XModel) PrepareEnv(tx *pb.Transaction) (*Env, error) {
 		return nil, err
 	}
 	env.modelCache = NewXModelCacheWithInputs(inputs, utxoInputs)
-
-	for _, verData := range inputs {
-		env.modelCache.fill(verData)
-	}
 	env.inputs = inputs
 	env.outputs = outputs
 	s.logger.Trace("PrepareEnv done!", "env", env)

--- a/xmodel/xmodel_cache.go
+++ b/xmodel/xmodel_cache.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// DefaultMemDBSize 默认内存db大小
-	DefaultMemDBSize = 50000
+	DefaultMemDBSize = 32
 )
 
 var (
@@ -265,15 +265,6 @@ func (xc *XMCache) isDel(rawKey []byte) bool {
 		return false
 	}
 	return isDelFlag(data.GetPureData().GetValue())
-}
-
-// fill 填充XModelCache, 当某个bucket, key已经存在的时候，会覆盖之前的值
-func (xc *XMCache) fill(vd *xmodel_pb.VersionedData) error {
-	bucket := vd.GetPureData().GetBucket()
-	key := vd.GetPureData().GetKey()
-	rawKey := makeRawKey(bucket, key)
-	valBuf, _ := proto.Marshal(vd)
-	return xc.inputsCache.Put(rawKey, valBuf)
 }
 
 // Transfer transfer tokens using utxo


### PR DESCRIPTION
## Description

The initial memory size can cause performance problems, set a small initial memory, the memory size will automatically grow as the cache becomes larger.