### PR TITLE
XRC01 fix table name

### DIFF
--- a/contractsdk/cpp/XRC/xrc01/src/main/xrc01.h
+++ b/contractsdk/cpp/XRC/xrc01/src/main/xrc01.h
@@ -11,7 +11,7 @@ public:
     XRC01(xchain::Context* ctx)
         : _token(ctx, "token"),
           _asset_info(ctx, "asset_info"),
-          _authorize_info(ctx, "_authorize_info") {
+          _authorize_info(ctx, "authorize_info") {
         _ctx = ctx;
     }
 


### PR DESCRIPTION
## Description

XRC01 protocol table name mis spelling, this commit fix the table name.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


