### PR TITLE
xvm: adjust the initial memory of the C++ contract to 1MB

### DIFF
--- a/contract/wasm/vm/xvm/creator.go
+++ b/contract/wasm/vm/xvm/creator.go
@@ -128,7 +128,10 @@ func (x *xvmCreator) CreateInstance(ctx *bridge.Context, cp vm.ContractCodeProvi
 	case "go":
 		gowasm.RegisterRuntime(execCtx)
 	case "c":
-		emscripten.Init(execCtx)
+		err = emscripten.Init(execCtx)
+		if err != nil {
+			return nil, err
+		}
 	}
 	execCtx.SetUserData(contextIDKey, ctx.ID)
 	instance := &xvmInstance{

--- a/contractsdk/cpp/Makefile
+++ b/contractsdk/cpp/Makefile
@@ -49,7 +49,7 @@ $(BUILD_DIR)/test/%.out: $(BUILD_DIR)/test/%.cc.o $(XCHAIN_CDT_LIBS) $(MOCK_CLAS
 
 # wasm target
 $(BUILD_DIR)/%.wasm: $(BUILD_DIR)/example/%.cc.o $(XCHAIN_CDT_LIBS) $(BUILD_DIR)/libxchain.a
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $^ -Oz -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s DETERMINISTIC=1 -L/usr/local/lib -lprotobuf-lite -lpthread
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $^ -Oz -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s DETERMINISTIC=1 -s TOTAL_STACK=256KB -s TOTAL_MEMORY=1MB -L/usr/local/lib -lprotobuf-lite -lpthread
 
 # c++ source
 $(BUILD_DIR)/%.cc.o: %.cc

--- a/contractsdk/xc/internal/cmd/build.go
+++ b/contractsdk/xc/internal/cmd/build.go
@@ -30,6 +30,8 @@ var (
 		"-Oz",
 		"-s ERROR_ON_UNDEFINED_SYMBOLS=0",
 		"-s WARN_ON_UNDEFINED_SYMBOLS=0",
+		"-s TOTAL_STACK=256KB",
+		"-s TOTAL_MEMORY=1MB",
 		"-s DETERMINISTIC=1",
 		"-L/usr/local/lib",
 		"-lprotobuf-lite",

--- a/xvm/compile/compile.go
+++ b/xvm/compile/compile.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 )
 
-const Version = "1.0"
+const Version = "2.0"
 
 // Config configures the compiler
 type Config struct {

--- a/xvm/compile/wabt/src/c-writer.cc
+++ b/xvm/compile/wabt/src/c-writer.cc
@@ -387,6 +387,7 @@ static const char* s_global_symbols[] = {
 static const char* HANDLE_TYPE = "wasm_rt_handle_t";
 static const char* USER_CTX_FIELD = "user_ctx";
 static const char* GAS_FIELD = "gas";
+static const char* STATIC_TOP_FIELD = "static_top";
 
 #define SECTION_NAME(x) s_header_##x
 #include "src/prebuilt/wasm2c.include.h"
@@ -921,6 +922,12 @@ void CWriter::WriteHandleFields() {
   // Write gas field
   Write("wasm_rt_gas_t ", DefineHandleFieldName(GAS_FIELD), ";", Newline());
 
+  // Write call deepth
+  Write("uint32_t ", DefineHandleFieldName("call_stack_depth"), ";", Newline());
+
+  // Write static data max offset
+  Write("uint32_t ", DefineHandleFieldName(STATIC_TOP_FIELD), ";", Newline());
+
   // Memory. include imports
   for (const Memory* memory : module_->memories) {
     WriteMemory(DefineHandleFieldName(memory->name));
@@ -938,9 +945,6 @@ void CWriter::WriteHandleFields() {
     WriteGlobal(*global, DefineHandleFieldName(global->name));
     Write(";", Newline());
   }
-
-  // Write call deepth
-  Write("uint32_t ", DefineHandleFieldName("call_stack_depth"), ";", Newline());
 }
 
 void CWriter::WriteFuncTypes() {
@@ -1080,6 +1084,14 @@ void CWriter::WriteTable(const std::string& name) {
   Write("wasm_rt_table_t ", name, ";");
 }
 
+static uint32_t DataSegmentOffset(const DataSegment* seg) {
+  const ExprList& expr_list = seg->offset;
+  assert(expr_list.size() == 1);
+  const Expr* expr = &expr_list.front();
+  assert(expr->type() == ExprType::Const);
+  return cast<ConstExpr>(expr)->const_.u32;
+}
+
 void CWriter::WriteDataInitializers() {
   const Memory* memory = nullptr;
   Index data_segment_index = 0;
@@ -1108,14 +1120,23 @@ void CWriter::WriteDataInitializers() {
   }
 
   Write(Newline(), "static void init_memory(wasm_rt_handle_t* h) ", OpenBrace());
+  uint32_t max_off = 0;
   if (memory) {
-    uint32_t max = memory->page_limits.has_max ? memory->page_limits.max : 65536;
+    uint32_t init_page = memory->page_limits.initial == 0 ? 1 : memory->page_limits.initial;
+    uint32_t max_page = memory->page_limits.has_max ? memory->page_limits.max : 65536;
+    uint32_t mem_size = init_page * 65536;
     Write("(*g_rt_ops.wasm_rt_allocate_memory)(",
           ExternalRef(USER_CTX_FIELD), ", ",
           ExternalPtr(memory->name), ", ",
-          memory->page_limits.initial, ", ", max, ");", Newline());
+          init_page, ", ", max_page, ");", Newline());
     data_segment_index = 0;
     for (const DataSegment* data_segment : module_->data_segments) {
+      uint32_t data_off = DataSegmentOffset(data_segment);
+      uint32_t mem_off = data_off + data_segment->data.size();
+      if (max_off < mem_off) {
+        max_off = mem_off;
+      }
+      assert(mem_off <= mem_size);
       Write("memcpy(&(", ExternalRef(memory->name), ".data[");
       WriteInitExpr(data_segment->offset);
       Write("]), data_segment_data_", data_segment_index, ", ",
@@ -1123,6 +1144,7 @@ void CWriter::WriteDataInitializers() {
       ++data_segment_index;
     }
   }
+  Write(ExternalRef(STATIC_TOP_FIELD), " = ", max_off, ";", Newline());
 
   Write(CloseBrace(), Newline());
 }

--- a/xvm/exec/context.go
+++ b/xvm/exec/context.go
@@ -6,7 +6,6 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"unsafe"
 )
 
@@ -123,12 +122,14 @@ func (c *Context) Memory() []byte {
 	if c.context.mem == nil || c.context.mem.size == 0 {
 		return nil
 	}
-	var mem []byte
-	header := (*reflect.SliceHeader)(unsafe.Pointer(&mem))
-	header.Data = uintptr(unsafe.Pointer(c.context.mem.data))
-	header.Len = int(c.context.mem.size)
-	header.Cap = int(c.context.mem.size)
-	return mem
+	ptr := c.context.mem.data
+	n := int(c.context.mem.size)
+	return (*[4 << 30]byte)(unsafe.Pointer(ptr))[:n:n]
+}
+
+// StaticTop returns the static data's top offset of memory
+func (c *Context) StaticTop() uint32 {
+	return uint32(C.xvm_mem_static_top(&c.context))
 }
 
 // SetUserData store key-value pair to Context which can be retrieved by GetUserData

--- a/xvm/exec/xvm.c
+++ b/xvm/exec/xvm.c
@@ -259,10 +259,12 @@ void xvm_release_code(xvm_code_t* code) {
  * xvm_context_t相关代码
  */
 
-// FIXME: 修改访问暴露变量的方式
+// NOTE: must sync with c-writer.cc CWriter::WriteHandleFields
 struct _wasm_rt_handle_t {
   void* user_ctx;
   wasm_rt_gas_t gas;
+  uint32_t call_stack_depth;
+  uint32_t static_top;
 };
 
 xvm_context_t* xvm_new_context(xvm_code_t* code) {
@@ -293,6 +295,11 @@ void xvm_release_context(xvm_context_t* ctx) {
     xvm_free(ctx->module_handle);
   }
   memset((void*)ctx, 0, sizeof(xvm_context_t));
+}
+
+uint32_t xvm_mem_static_top(xvm_context_t* ctx) {
+    struct _wasm_rt_handle_t* _handle = ctx->module_handle;
+    return _handle->static_top;
 }
 
 uint32_t xvm_call(xvm_context_t* ctx, char* name, int64_t* params, int64_t param_len, wasm_rt_gas_t* gas, int64_t* ret) {

--- a/xvm/exec/xvm.h
+++ b/xvm/exec/xvm.h
@@ -63,6 +63,7 @@ typedef struct xvm_context_t {
 int xvm_init_context(xvm_context_t* ctx, xvm_code_t* code);
 void xvm_release_context(xvm_context_t* ctx);
 uint32_t xvm_call(xvm_context_t* ctx, char* name, int64_t* params, int64_t param_len, wasm_rt_gas_t* gas, int64_t* ret);
+uint32_t xvm_mem_static_top(xvm_context_t* ctx);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
1. Add StaticTop to get the top offset of static data.
2. Adjust stack size to 256KB.
3. Adjust initial memory of C++ contract to 1MB, may add dynamic memory grow in the future.