### PR TITLE
Bugfix: validate if txid has been forbidden by checking contract status

### DIFF
--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -1911,10 +1911,10 @@ func (uv *UtxoVM) queryTxFromForbiddenWithConfirmed(txid []byte) (bool, bool, er
 	if err != nil {
 		return false, false, err
 	}
-	invokeRes, err = ctx.Invoke(request.GetMethodName(), request.GetArgs())
-	if err != nil {
+	invokeRes, invokeErr := ctx.Invoke(request.GetMethodName(), request.GetArgs())
+	if invokeErr != nil {
 		ctx.Release()
-		return false, false, err
+		return false, false, invokeErr
 	}
 	ctx.Release()
 	// 判断forbidden合约的结果

--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -1881,6 +1881,10 @@ func (uv *UtxoVM) queryTxFromForbiddenWithConfirmed(txid []byte) (bool, bool, er
 	contractNameForForbidden := forbiddenContract.ContractName
 	methodNameForForbidden := forbiddenContract.MethodName
 
+	if moduleNameForForbidden == "" && contractNameForForbidden == "" && methodNameForForbidden == "" {
+		return false, false, nil
+	}
+
 	request := &pb.InvokeRequest{
 		ModuleName:   moduleNameForForbidden,
 		ContractName: contractNameForForbidden,
@@ -1907,12 +1911,16 @@ func (uv *UtxoVM) queryTxFromForbiddenWithConfirmed(txid []byte) (bool, bool, er
 	if err != nil {
 		return false, false, err
 	}
-	_, err = ctx.Invoke(request.GetMethodName(), request.GetArgs())
+	invokeRes, err = ctx.Invoke(request.GetMethodName(), request.GetArgs())
 	if err != nil {
 		ctx.Release()
 		return false, false, err
 	}
 	ctx.Release()
+	// 判断forbidden合约的结果
+	if invokeRes.Status >= 400 {
+		return false, false, nil
+	}
 	// inputs as []*xmodel_pb.VersionedData
 	inputs, _, _ := modelCache.GetRWSets()
 	versionData := &xmodel_pb.VersionedData{}


### PR DESCRIPTION
## Description

What is the purpose of the change?

The mechanism of contract status has been modified from client's point of view, so the client should change the way to validate the result of contract calling by checking contract status.

Fixes #485 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## Brief of your solution

Checking the result of contract calling by contract status.

## How Has This Been Tested?

Regression Test
