### PR TITLE
contractsdk/cpp: add a new call_method interface to reduce the number of c to go calls

### DIFF
--- a/xvm/exec/codec.go
+++ b/xvm/exec/codec.go
@@ -48,6 +48,12 @@ func (c Codec) Uint32(addr uint32) uint32 {
 	return binary.LittleEndian.Uint32(buf)
 }
 
+// SetUint32 set val to memory[addr:addr+4]
+func (c Codec) SetUint32(addr uint32, val uint32) {
+	buf := c.Bytes(addr, 4)
+	binary.LittleEndian.PutUint32(buf, val)
+}
+
 // Uint64 decodes memory[addr:addr+8] to uint64
 func (c Codec) Uint64(addr uint32) uint64 {
 	buf := c.Bytes(addr, 8)

--- a/xvm/exec/resolver.go
+++ b/xvm/exec/resolver.go
@@ -166,6 +166,26 @@ func applyFuncCall(ctx *Context, f interface{}, params []uint32) (uint32, bool) 
 			return 0, false
 		}
 		return fun(ctx, params[0], params[1], params[2], params[3]), true
+	case func(*Context, uint32, uint32, uint32, uint32, uint32) uint32:
+		if len != 5 {
+			return 0, false
+		}
+		return fun(ctx, params[0], params[1], params[2], params[3], params[4]), true
+	case func(*Context, uint32, uint32, uint32, uint32, uint32, uint32) uint32:
+		if len != 6 {
+			return 0, false
+		}
+		return fun(ctx, params[0], params[1], params[2], params[3], params[4], params[5]), true
+	case func(*Context, uint32, uint32, uint32, uint32, uint32, uint32, uint32) uint32:
+		if len != 7 {
+			return 0, false
+		}
+		return fun(ctx, params[0], params[1], params[2], params[3], params[4], params[5], params[6]), true
+	case func(*Context, uint32, uint32, uint32, uint32, uint32, uint32, uint32, uint32) uint32:
+		if len != 8 {
+			return 0, false
+		}
+		return fun(ctx, params[0], params[1], params[2], params[3], params[4], params[5], params[6], params[7]), true
 	default:
 		return 0, false
 	}


### PR DESCRIPTION
The call from c to go has overhead, this commit will make the syscall in most cases complete by one call.