### PR TITLE
control utxo cache size more accurately

### DIFF
--- a/conf/xchain.yaml
+++ b/conf/xchain.yaml
@@ -45,8 +45,8 @@ datapath: ./data/blockchain
 #    - /ssd3/blockchain
 
 utxo:
-# utxo的内存LRUCache大小，默认100000个address, 这个需要根据一个block里address的容量来考虑
-  cachesize: 100000
+# utxo的内存LRUCache大小，表示内存中最多缓存多少个UtxoItem
+  cachesize: 2000000
 # GenerateTx的临时锁定期限，默认是600秒
   tmplockSeconds: 600
 #单个块的合约执行的总时间(单位ms)

--- a/utxo/utxo_cache.go
+++ b/utxo/utxo_cache.go
@@ -5,13 +5,17 @@ import (
 	"sync"
 )
 
+type CacheItem struct {
+	UtxoItem
+	ele *list.Element
+}
+
 // UtxoCache is a in-memory cache of UTXO
 type UtxoCache struct {
 	// <ADDRESS, <UTXO_KEY, UTXO_ITEM>>
-	Available map[string]map[string]*UtxoItem
-	All       map[string]map[string]*UtxoItem
+	Available map[string]map[string]*CacheItem
+	All       map[string]map[string]*CacheItem
 	List      *list.List
-	nodes     map[string]*list.Element
 	Limit     int
 	mutex     *sync.Mutex
 }
@@ -19,10 +23,9 @@ type UtxoCache struct {
 // NewUtxoCache create instance of UtxoCache
 func NewUtxoCache(limit int) *UtxoCache {
 	return &UtxoCache{
-		Available: map[string]map[string]*UtxoItem{},
-		All:       map[string]map[string]*UtxoItem{},
+		Available: map[string]map[string]*CacheItem{},
+		All:       map[string]map[string]*CacheItem{},
 		List:      list.New(),
-		nodes:     map[string]*list.Element{},
 		Limit:     limit,
 		mutex:     &sync.Mutex{},
 	}
@@ -33,24 +36,17 @@ func (uv *UtxoCache) Insert(addr string, utxoKey string, item *UtxoItem) {
 	uv.mutex.Lock()
 	defer uv.mutex.Unlock()
 	if _, exist := uv.All[addr]; !exist {
-		uv.Available[addr] = map[string]*UtxoItem{}
-		uv.All[addr] = map[string]*UtxoItem{}
+		uv.Available[addr] = map[string]*CacheItem{}
+		uv.All[addr] = map[string]*CacheItem{}
 	}
-	uv.Available[addr][utxoKey] = item
-	uv.All[addr][utxoKey] = item
-	if node, ok := uv.nodes[addr]; ok {
-		uv.List.MoveToFront(node) //挪到前面
-	} else {
-		ele := uv.List.PushFront(addr)
-		uv.nodes[addr] = ele
-	}
+	ele := uv.List.PushFront([]string{addr, utxoKey})
+	cacheItem := &CacheItem{UtxoItem{Amount: item.Amount, FrozenHeight: item.FrozenHeight}, ele}
+	uv.Available[addr][utxoKey] = cacheItem
+	uv.All[addr][utxoKey] = cacheItem
 	if uv.List.Len() > uv.Limit {
-		ele := uv.List.Back() //最近最少使用的address
-		address := ele.Value.(string)
-		delete(uv.Available, address)
-		delete(uv.All, address)
-		delete(uv.nodes, address)
-		uv.List.Remove(ele)
+		oldEle := uv.List.Back() //最近最少使用的address
+		addressUtxoKey := oldEle.Value.([]string)
+		uv.remove(addressUtxoKey[0], addressUtxoKey[1])
 	}
 }
 
@@ -61,28 +57,28 @@ func (uv *UtxoCache) Use(address string, utxoKey string) {
 	}
 }
 
-// Remove delete uxto key from cache
-func (uv *UtxoCache) Remove(address string, utxoKey string) {
-	uv.mutex.Lock()
-	defer uv.mutex.Unlock()
+func (uv *UtxoCache) remove(address string, utxoKey string) {
 	if l2, exist := uv.All[address]; exist {
-		delete(l2, utxoKey)
+		cacheItem, _ := l2[utxoKey]
+		if cacheItem != nil {
+			uv.List.Remove(cacheItem.ele)
+			delete(l2, utxoKey)
+		}
 		if len(l2) == 0 { //这个address的utxo删完了
 			delete(uv.All, address)
 			delete(uv.Available, address)
-			if ele, ok := uv.nodes[address]; ok {
-				delete(uv.nodes, address)
-				uv.List.Remove(ele)
-			}
-		} else {
-			if ele, ok := uv.nodes[address]; ok {
-				uv.List.MoveToFront(ele) //挪到前面
-			}
 		}
 	}
 	if l2, exist := uv.Available[address]; exist {
 		delete(l2, utxoKey)
 	}
+}
+
+// Remove delete uxto key from cache
+func (uv *UtxoCache) Remove(address string, utxoKey string) {
+	uv.mutex.Lock()
+	defer uv.mutex.Unlock()
+	uv.remove(address, utxoKey)
 }
 
 // Lock used to lock cache


### PR DESCRIPTION
## Description

Previously, the utxo cache was address granularity, which made it difficult to control the exact memory size, because there were many utxo in some addresses. Now, the size of the cache was changed to UtxoItem granularity, which made it more reasonable to control the exact memory size.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)


## Brief of your solution
If the cache runs out, the oldest UtxoItem will become expired, regardless of which address it belongs to

## How Has This Been Tested?
XuperBench test

