### PR TITLE
backport: add check for contract memory size

### DIFF
--- a/contract/wasm/vm/xvm/creator.go
+++ b/contract/wasm/vm/xvm/creator.go
@@ -128,7 +128,10 @@ func (x *xvmCreator) CreateInstance(ctx *bridge.Context, cp vm.ContractCodeProvi
 	case "go":
 		gowasm.RegisterRuntime(execCtx)
 	case "c":
-		emscripten.Init(execCtx)
+		err = emscripten.Init(execCtx)
+		if err != nil {
+			return nil, err
+		}
 	}
 	execCtx.SetUserData(contextIDKey, ctx.ID)
 	instance := &xvmInstance{

--- a/xvm/runtime/emscripten/resolver.go
+++ b/xvm/runtime/emscripten/resolver.go
@@ -1,6 +1,7 @@
 package emscripten
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"unsafe"
@@ -32,14 +33,18 @@ func getMutableGlobals(ctx *exec.Context) *mutableGlobals {
 }
 
 // Init initialize global variables
-func Init(ctx *exec.Context) {
+func Init(ctx *exec.Context) error {
 	mem := ctx.Memory()
 	if mem == nil {
-		return
+		return errors.New("no memory")
+	}
+	if mutableGlobalsBase >= len(mem) {
+		return errors.New("bad memory size")
 	}
 	mg := (*mutableGlobals)(unsafe.Pointer(&mem[mutableGlobalsBase]))
 	mg.DynamicTop = stackMax
 	ctx.SetUserData(mutableGlobalsKey, mg)
+	return nil
 }
 
 // NewResolver return exec.Resolver which resolves symbols needed by emscripten environment


### PR DESCRIPTION
## Description

Master branch has changed the initial memory size of contract, In order to prevent users from mistakenly deploying the contract to the mainnet, add check for contract memory size.