### PR TITLE
fix the leak of utxo lock

### DIFF
--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -1092,6 +1092,7 @@ func (uv *UtxoVM) doTxInternal(tx *pb.Transaction, batch kvdb.Batch) error {
 		utxoKey := GenUtxoKeyWithPrefix(addr, txid, offset)
 		batch.Delete([]byte(utxoKey)) // 删除用掉的utxo
 		uv.utxoCache.Remove(string(addr), utxoKey)
+		uv.unlockKey([]byte(utxoKey))
 		uv.subBalance(addr, big.NewInt(0).SetBytes(txInput.Amount))
 		if !uv.asyncMode {
 			uv.xlog.Trace("    delete utxo key", "utxoKey", utxoKey)


### PR DESCRIPTION
## Description

utxo lock items in memory only expire after 10 minites by default. Therefore, when TPS of requests if high, the memeory footprint will increase rapidly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution
remove the utxo lock when dotx

## How Has This Been Tested?
Regression Test
