### PR TITLE
Batch reuse to improve performance

### DIFF
--- a/conf/xchain.yaml
+++ b/conf/xchain.yaml
@@ -47,9 +47,9 @@ datapath: ./data/blockchain
 utxo:
   # utxo的内存LRUCache大小，表示内存中最多缓存多少个UtxoItem
   cachesize: 2000000
-  # GenerateTx的临时锁定期限，默认是600秒
-  tmplockSeconds: 600
-  #单个块的合约执行的总时间(单位ms)
+# GenerateTx的临时锁定期限，默认是60秒
+  tmplockSeconds: 60
+#单个块的合约执行的总时间(单位ms)
   contractExecutionTime: 500
 
 kernel:

--- a/kv/kvdb/plugin-ldb/ldb_impl.go
+++ b/kv/kvdb/plugin-ldb/ldb_impl.go
@@ -148,5 +148,5 @@ func (b *ldbBatch) ValueSize() int {
 func (b *ldbBatch) Reset() {
 	b.b.Reset()
 	b.size = 0
-	b.keys =  map[string]bool{}
+	b.keys = map[string]bool{}
 }

--- a/kv/kvdb/plugin-ldb/ldb_impl.go
+++ b/kv/kvdb/plugin-ldb/ldb_impl.go
@@ -148,4 +148,5 @@ func (b *ldbBatch) ValueSize() int {
 func (b *ldbBatch) Reset() {
 	b.b.Reset()
 	b.size = 0
+	b.keys =  map[string]bool{}
 }

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -79,7 +79,7 @@ type Ledger struct {
 	cryptoClient     crypto_base.CryptoClient
 	enablePowMinning bool
 	powMutex         *sync.Mutex
-	confirmBatch     kvdb.Batch       //新增区块
+	confirmBatch     kvdb.Batch //新增区块
 }
 
 // ConfirmStatus block status

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -79,6 +79,7 @@ type Ledger struct {
 	cryptoClient     crypto_base.CryptoClient
 	enablePowMinning bool
 	powMutex         *sync.Mutex
+	confirmBatch     kvdb.Batch       //新增区块
 }
 
 // ConfirmStatus block status
@@ -133,6 +134,7 @@ func NewLedger(storePath string, xlog log.Logger, otherPaths []string, kvEngineT
 	ledger.blkHeaderCache = common.NewLRUCache(BlockCacheSize)
 	ledger.cryptoClient = cryptoClient
 	ledger.enablePowMinning = true
+	ledger.confirmBatch = baseDB.NewBatch()
 	metaBuf, metaErr := ledger.metaTable.Get([]byte(""))
 	emptyLedger := false
 	if metaErr != nil && common.NormalizedKVError(metaErr) == common.ErrKVNotFound { //说明是新创建的账本
@@ -553,7 +555,8 @@ func (l *Ledger) ConfirmBlock(block *pb.InternalBlock, isRoot bool) ConfirmStatu
 	realTransactions := block.Transactions // 真正的交易转存到局部变量
 	block.Transactions = dummyTransactions // block表不保存transaction详情
 
-	batchWrite := l.baseDB.NewBatch()
+	batchWrite := l.confirmBatch
+	batchWrite.Reset()
 	newMeta := proto.Clone(l.meta).(*pb.LedgerMeta)
 	splitHeight := newMeta.TrunkHeight
 	if isRoot { //确认创世块

--- a/utxo/async.go
+++ b/utxo/async.go
@@ -80,7 +80,7 @@ func (uv *UtxoVM) flushTxList(txList []*pb.Transaction) error {
 	}
 	batch := uv.asyncBatch
 	batch.Reset()
-	for i, tx := range txList {
+	for _, tx := range txList {
 		if conflictedTxs[string(tx.Txid)] {
 			continue
 		}

--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -138,6 +138,8 @@ type UtxoVM struct {
 	asyncWriterWG        *sync.WaitGroup      // 优雅退出异步writer的信号量
 	asyncCond            *sync.Cond           // 用来出块线程优先权的条件变量
 	asyncTryBlockGen     bool                 // doMiner线程是否准备出块
+	asyncResult          *AsyncResult         // 用于等待异步结果
+	asyncBatch           kvdb.Batch           // 异步worker复用batch
 	vatHandler           *vat.VATHandler      // Verifiable Autogen Tx 生成器
 	balanceCache         *common.LRUCache     //余额cache,加速GetBalance查询
 	cacheSize            int                  //记录构造utxo时传入的cachesize
@@ -418,6 +420,8 @@ func MakeUtxoVM(bcname string, ledger *ledger_pkg.Ledger, storePath string, priv
 		asyncWriterWG:        &sync.WaitGroup{},
 		asyncCond:            sync.NewCond(utxoMutex),
 		asyncTryBlockGen:     false,
+		asyncResult:          &AsyncResult{},
+		asyncBatch:           baseDB.NewBatch(),
 		balanceCache:         common.NewLRUCache(cachesize),
 		cacheSize:            cachesize,
 		balanceViewDirty:     map[string]bool{},

--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -138,7 +138,6 @@ type UtxoVM struct {
 	asyncWriterWG        *sync.WaitGroup      // 优雅退出异步writer的信号量
 	asyncCond            *sync.Cond           // 用来出块线程优先权的条件变量
 	asyncTryBlockGen     bool                 // doMiner线程是否准备出块
-	asyncResult          *AsyncResult         // 用于等待异步结果
 	asyncBatch           kvdb.Batch           // 异步worker复用batch
 	vatHandler           *vat.VATHandler      // Verifiable Autogen Tx 生成器
 	balanceCache         *common.LRUCache     //余额cache,加速GetBalance查询
@@ -420,7 +419,6 @@ func MakeUtxoVM(bcname string, ledger *ledger_pkg.Ledger, storePath string, priv
 		asyncWriterWG:        &sync.WaitGroup{},
 		asyncCond:            sync.NewCond(utxoMutex),
 		asyncTryBlockGen:     false,
-		asyncResult:          &AsyncResult{},
 		asyncBatch:           baseDB.NewBatch(),
 		balanceCache:         common.NewLRUCache(cachesize),
 		cacheSize:            cachesize,

--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -125,22 +125,22 @@ type UtxoVM struct {
 	model3            *xmodel.XModel           // XuperModel实例，处理extutxo
 	vmMgr3            *contract.VMManager
 	aclMgr            *acli.Manager // ACL manager for read/write acl table
-	minerPublicKey  string
-	minerPrivateKey string
-	minerAddress    []byte
-	failedTxBuf     map[string][]string
-	inboundTxChan    chan *InboundTx      // 异步tx chan
-	verifiedTxChan   chan *pb.Transaction //已经校验通过的tx
-	asyncMode        bool                 // 是否工作在异步模式
-	asyncCancel      context.CancelFunc   // 停止后台异步batch写的句柄
-	asyncWriterWG    *sync.WaitGroup      // 优雅退出异步writer的信号量
-	asyncCond        *sync.Cond           // 用来出块线程优先权的条件变量
-	asyncTryBlockGen bool                 // doMiner线程是否准备出块
-	asyncResult      *AsyncResult         // 用于等待异步结果
+	minerPublicKey    string
+	minerPrivateKey   string
+	minerAddress      []byte
+	failedTxBuf       map[string][]string
+	inboundTxChan     chan *InboundTx      // 异步tx chan
+	verifiedTxChan    chan *pb.Transaction //已经校验通过的tx
+	asyncMode         bool                 // 是否工作在异步模式
+	asyncCancel       context.CancelFunc   // 停止后台异步batch写的句柄
+	asyncWriterWG     *sync.WaitGroup      // 优雅退出异步writer的信号量
+	asyncCond         *sync.Cond           // 用来出块线程优先权的条件变量
+	asyncTryBlockGen  bool                 // doMiner线程是否准备出块
+	asyncResult       *AsyncResult         // 用于等待异步结果
 	// 上述asyncMode是指异步模式，默认是异步回调模式
 	// asyncBlockMode是指异步阻塞模式
 	asyncBlockMode       bool             // 是否工作在异步阻塞模式下
-  asyncBatch           kvdb.Batch       // 异步刷盘复用的batch
+	asyncBatch           kvdb.Batch       // 异步刷盘复用的batch
 	vatHandler           *vat.VATHandler  // Verifiable Autogen Tx 生成器
 	balanceCache         *common.LRUCache //余额cache,加速GetBalance查询
 	cacheSize            int              //记录构造utxo时传入的cachesize
@@ -424,7 +424,7 @@ func MakeUtxoVM(bcname string, ledger *ledger_pkg.Ledger, storePath string, priv
 		asyncResult:       &AsyncResult{},
 		// asyncBlockMode indidates that it is blocked when postTx
 		asyncBlockMode:       false,
-    asyncBatch:           baseDB.NewBatch(),
+		asyncBatch:           baseDB.NewBatch(),
 		balanceCache:         common.NewLRUCache(cachesize),
 		cacheSize:            cachesize,
 		balanceViewDirty:     map[string]bool{},


### PR DESCRIPTION
## Description
When data in kvdb.Batch is large, the underlying bytes buffer have to grow frequently. 
It is better to reuse the batch object, so that no buffer growth needed in runtime.

## Type of change

- [ ] Performance Ehancement (non-breaking change which adds functionality)

## Brief of your solution
Before reuse a batch, call batch.Reset

## How Has This Been Tested?
make test
