### PR TITLE
xvm: error handle for function not found

### DIFF
--- a/xvm/exec/context.go
+++ b/xvm/exec/context.go
@@ -14,6 +14,14 @@ const (
 	MaxGasLimit = 0xFFFFFFFF
 )
 
+type ErrFuncNotFound struct {
+	Name string
+}
+
+func (e *ErrFuncNotFound) Error() string {
+	return fmt.Sprintf("%s not found", e.Name)
+}
+
 // ContextConfig configures an execution context
 type ContextConfig struct {
 	GasLimit int64
@@ -103,7 +111,9 @@ func (c *Context) Exec(name string, param []int64) (ret int64, err error) {
 	var cret C.int64_t
 	ok := C.xvm_call(&c.context, cname, args, C.int64_t(len(param)), &cret)
 	if ok == 0 {
-		return 0, fmt.Errorf("%s not found", name)
+		return 0, &ErrFuncNotFound{
+			Name: name,
+		}
 	}
 	ret = int64(cret)
 	return

--- a/xvm/runtime/emscripten/resolver.go
+++ b/xvm/runtime/emscripten/resolver.go
@@ -37,6 +37,9 @@ func getMutableGlobals(ctx *exec.Context) *mutableGlobals {
 func memoryStackBase(ctx *exec.Context) (uint32, error) {
 	base, err := ctx.Exec(stackAllocFunc, []int64{0})
 	if err != nil {
+		if _, ok := err.(*exec.ErrFuncNotFound); !ok {
+			return 0, err
+		}
 		// stackAllocFunc not found, fallback to StaticTop method.
 		base := ctx.StaticTop()
 		// align 4K boundry


### PR DESCRIPTION
Handle function not found error explicitly.
