### PR TITLE
Fix block verified failed while block height equal 2

### DIFF
--- a/consensus/common/chainedbft/smr/safety_rules.go
+++ b/consensus/common/chainedbft/smr/safety_rules.go
@@ -25,10 +25,11 @@ func (s *Smr) safeProposal(propsQC, justify *pb.QuorumCert) (bool, error) {
 		s.slog.Warn("safeProposal justify is nil")
 		return s.externalCons.CallVerifyQc(propsQC)
 	}
-	// if ok, err := s.IsQuorumCertValidate(justify); !ok || err != nil {
-	// 	s.slog.Error("safeProposal IsQuorumCertValidate error", "ok", ok, "error", err)
-	// 	return false, err
-	// }
+
+	if ok, err := s.IsQuorumCertValidate(justify); !ok || err != nil {
+		s.slog.Error("safeProposal IsQuorumCertValidate error", "ok", ok, "error", err)
+		return false, err
+	}
 	// step3: call external consensus verify proposalMsg
 	return s.externalCons.CallVerifyQc(propsQC)
 }


### PR DESCRIPTION
## Description

What is the purpose of the change?
Fix block verified failed while block height equal 2. Qc.justify’s sign infos haven't been validated while processing safety rule checking.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Brief of your solution
Checking Qc.justify’s sign infos in `safeProposal` function.
