### PR TITLE
No immediately tx reposting in async mode

### DIFF
--- a/core/xchaincore.go
+++ b/core/xchaincore.go
@@ -898,8 +898,8 @@ func (xc *XChainCore) PostTx(in *pb.TxStatus, hd *global.XContext) (*pb.CommonRe
 		return out, false
 	}
 	xc.Speed.Add("PostTx")
-	if xc.Utxovm.IsAsync() {
-		return out, xc.Utxovm.IsInUnConfirm(string(in.Txid))
+	if xc.Utxovm.IsAsync() || xc.Utxovm.IsAsyncBlock() {
+		return out, false //no need to repost tx immediately
 	}
 	return out, true
 }


### PR DESCRIPTION
## Description
There is already a regular tx repost mechanism. In asynchronous mode, the immediate forwarding function is removed to reduce the overhead of out-of-order transactions requests.

## Type of change

Please delete options that are not relevant.

- [ ] No Breaking change

## Brief of your solution

Please describe your solution to solve the issue or feature request.

## How Has This Been Tested?
XuperBench