### PR TITLE
Bugfix: Use copy instead of reference

### DIFF
--- a/contract/kernel/kernel_test.go
+++ b/contract/kernel/kernel_test.go
@@ -563,7 +563,6 @@ func TestRunUpdateForbiddenContract(t *testing.T) {
 	if runUpdateBlkChainErr != nil {
 		t.Error("runUpdateForbiddenContract error:->", runUpdateBlkChainErr.Error())
 	}
-
 	rollbackUpdateBlkChainErr := kl.rollbackUpdateForbiddenContract(txDesc)
 	if rollbackUpdateBlkChainErr != nil {
 		t.Error("runUpdateForbiddenContract error:->", rollbackUpdateBlkChainErr.Error())
@@ -589,8 +588,8 @@ func TestRunUpdateForbiddenContract(t *testing.T) {
 	}
 	currentNewAccountResourceAmount := utxovm.GetNewAccountResourceAmount()
 	t.Log("new newAccountResourceAmount->", currentNewAccountResourceAmount)
-	if currentNewAccountResourceAmount != 100 {
-		t.Error("expect 100, but got ", currentNewAccountResourceAmount)
+	if currentNewAccountResourceAmount != 1000 {
+		t.Error("expect 1000, but got ", currentNewAccountResourceAmount)
 	}
 	rollbackUpdateNewAccountResourceAmountErr := kl.rollbackUpdateNewAccountResourceAmount(txDesc)
 	if rollbackUpdateNewAccountResourceAmountErr != nil {

--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -510,7 +510,8 @@ func MakeUtxoVM(bcname string, ledger *ledger_pkg.Ledger, storePath string, priv
 		return nil, loadErr
 	}
 	// cp not reference
-	utxoVM.metaTmp = proto.Clone(utxoVM.meta).(*pb.UtxoMeta)
+	newMeta := proto.Clone(utxoVM.meta).(*pb.UtxoMeta)
+	utxoVM.metaTmp = newMeta
 	return utxoVM, nil
 }
 
@@ -1585,7 +1586,8 @@ func (uv *UtxoVM) PlayAndRepost(blockid []byte, needRepost bool, isRootTx bool) 
 	// 内存级别更新UtxoMeta信息
 	uv.mutexMeta.Lock()
 	defer uv.mutexMeta.Unlock()
-	uv.meta = proto.Clone(uv.metaTmp).(*pb.UtxoMeta)
+	newMeta := proto.Clone(uv.metaTmp).(*pb.UtxoMeta)
+	uv.meta = newMeta
 	return nil
 }
 
@@ -1651,7 +1653,8 @@ func (uv *UtxoVM) PlayForMiner(blockid []byte, batch kvdb.Batch) error {
 	// 内存级别更新UtxoMeta信息
 	uv.mutexMeta.Lock()
 	defer uv.mutexMeta.Unlock()
-	uv.meta = proto.Clone(uv.metaTmp).(*pb.UtxoMeta)
+	newMeta := proto.Clone(uv.metaTmp).(*pb.UtxoMeta)
+	uv.meta = newMeta
 	return nil
 }
 
@@ -1771,7 +1774,8 @@ func (uv *UtxoVM) Walk(blockid []byte, ledgerPrune bool) error {
 		}
 		// 内存级别更新UtxoMeta信息
 		uv.mutexMeta.Lock()
-		uv.meta = proto.Clone(uv.metaTmp).(*pb.UtxoMeta)
+		newMeta := proto.Clone(uv.metaTmp).(*pb.UtxoMeta)
+		uv.meta = newMeta
 		uv.mutexMeta.Unlock()
 	}
 	for i := len(todoBlocks) - 1; i >= 0; i-- {
@@ -1829,7 +1833,8 @@ func (uv *UtxoVM) Walk(blockid []byte, ledgerPrune bool) error {
 		}
 		// 内存级别更新UtxoMeta信息
 		uv.mutexMeta.Lock()
-		uv.meta = proto.Clone(uv.metaTmp).(*pb.UtxoMeta)
+		newMeta := proto.Clone(uv.metaTmp).(*pb.UtxoMeta)
+		uv.meta = newMeta
 		uv.mutexMeta.Unlock()
 	}
 	return nil

--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -509,7 +509,8 @@ func MakeUtxoVM(bcname string, ledger *ledger_pkg.Ledger, storePath string, priv
 		xlog.Warn("failed to load gas price from disk", "loadErr", loadErr)
 		return nil, loadErr
 	}
-	utxoVM.metaTmp = utxoVM.meta
+	// cp not reference
+	utxoVM.metaTmp = proto.Clone(utxoVM.meta).(*pb.UtxoMeta)
 	return utxoVM, nil
 }
 
@@ -1584,7 +1585,7 @@ func (uv *UtxoVM) PlayAndRepost(blockid []byte, needRepost bool, isRootTx bool) 
 	// 内存级别更新UtxoMeta信息
 	uv.mutexMeta.Lock()
 	defer uv.mutexMeta.Unlock()
-	uv.meta = uv.metaTmp
+	uv.meta = proto.Clone(uv.metaTmp).(*pb.UtxoMeta)
 	return nil
 }
 
@@ -1650,7 +1651,7 @@ func (uv *UtxoVM) PlayForMiner(blockid []byte, batch kvdb.Batch) error {
 	// 内存级别更新UtxoMeta信息
 	uv.mutexMeta.Lock()
 	defer uv.mutexMeta.Unlock()
-	uv.meta = uv.metaTmp
+	uv.meta = proto.Clone(uv.metaTmp).(*pb.UtxoMeta)
 	return nil
 }
 
@@ -1770,7 +1771,7 @@ func (uv *UtxoVM) Walk(blockid []byte, ledgerPrune bool) error {
 		}
 		// 内存级别更新UtxoMeta信息
 		uv.mutexMeta.Lock()
-		uv.meta = uv.metaTmp
+		uv.meta = proto.Clone(uv.metaTmp).(*pb.UtxoMeta)
 		uv.mutexMeta.Unlock()
 	}
 	for i := len(todoBlocks) - 1; i >= 0; i-- {
@@ -1828,7 +1829,7 @@ func (uv *UtxoVM) Walk(blockid []byte, ledgerPrune bool) error {
 		}
 		// 内存级别更新UtxoMeta信息
 		uv.mutexMeta.Lock()
-		uv.meta = uv.metaTmp
+		uv.meta = proto.Clone(uv.metaTmp).(*pb.UtxoMeta)
 		uv.mutexMeta.Unlock()
 	}
 	return nil


### PR DESCRIPTION
We plan to implement atomic ability by using double-copy mechanism.
However, we use reference mistakenly.

Fixes # (issue)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution

Use proto.Clone to imitate the command of copy.

## How Has This Been Tested?

Regression Test
