### PR TITLE
xvm: add support for go1.13 runtime

### DIFF
--- a/xvm/runtime/go/js/builtins.go
+++ b/xvm/runtime/go/js/builtins.go
@@ -7,6 +7,11 @@ func Array(args []interface{}) interface{} {
 
 // Uint8Array simulates Uint8Array function
 func Uint8Array(args []interface{}) interface{} {
+	// for new Uint8Array(n)
+	if len(args) == 1 {
+		return make([]byte, args[0].(int64))
+	}
+	// for new Uint8Array(buffer, 0, n)
 	mem, ok := args[0].([]byte)
 	if !ok {
 		ThrowException(ExceptionInvalidArgument)

--- a/xvm/runtime/go/js/value.go
+++ b/xvm/runtime/go/js/value.go
@@ -1,6 +1,7 @@
 package js
 
 import (
+	"errors"
 	"fmt"
 	"math"
 )
@@ -20,6 +21,15 @@ func (v *Value) String() string {
 // Name is used for debugging
 func (v *Value) Name() string {
 	return v.name
+}
+
+// Bytes return ref as []byte, error will return if type of ref is not Uint8Array
+func (v *Value) Bytes() ([]byte, error) {
+	slice, ok := v.value.([]byte)
+	if !ok {
+		return nil, errors.New("not Uint8Array")
+	}
+	return slice, nil
 }
 
 // predefined values

--- a/xvm/runtime/go/js/vm.go
+++ b/xvm/runtime/go/js/vm.go
@@ -311,8 +311,3 @@ func (vm *VM) CatchException(e *Ref) {
 	}
 	*e = vm.Exception(exp)
 }
-
-// Bytes return ref as []byte, error will return if type of ref is not Uint8Array
-func (vm *VM) Bytes(ref Ref) ([]byte, error) {
-	return nil, nil
-}

--- a/xvm/runtime/go/js/vm.go
+++ b/xvm/runtime/go/js/vm.go
@@ -311,3 +311,8 @@ func (vm *VM) CatchException(e *Ref) {
 	}
 	*e = vm.Exception(exp)
 }
+
+// Bytes return ref as []byte, error will return if type of ref is not Uint8Array
+func (vm *VM) Bytes(ref Ref) ([]byte, error) {
+	return nil, nil
+}

--- a/xvm/runtime/go/resolver.go
+++ b/xvm/runtime/go/resolver.go
@@ -60,6 +60,10 @@ func (r *resolver) resolveFunc(module, name string) (interface{}, bool) {
 		return (*Runtime).syscallJsValueSetIndex, true
 	case "go::syscall/js.valueInstanceOf":
 		return (*Runtime).syscallJsValueInstanceOf, true
+	case "go::syscall/js.copyBytesToGo": // for go1.13
+		return (*Runtime).syscallJsCopyBytesToGo, true
+	case "go::syscall/js.copyBytesToJS": // for go1.13
+		return (*Runtime).syscallJsCopyBytesToJS, true
 	}
 	return nil, false
 }

--- a/xvm/runtime/go/runtime.go
+++ b/xvm/runtime/go/runtime.go
@@ -154,3 +154,29 @@ func (rt *Runtime) syscallJsValueLength(ref js.Ref) int64 {
 
 func (rt *Runtime) syscallJsValueInstanceOf(v, t js.Ref) {
 }
+
+func (rt *Runtime) syscallJsCopyBytesToGo(dst []byte, src js.Ref) (int64, bool) {
+	v := rt.jsvm.Value(src)
+	if v == nil {
+		return 0, false
+	}
+	slice, err := v.Bytes()
+	if err != nil {
+		return 0, false
+	}
+	n := copy(dst, slice)
+	return int64(n), true
+}
+
+func (rt *Runtime) syscallJsCopyBytesToJS(dst js.Ref, src []byte) (int64, bool) {
+	v := rt.jsvm.Value(dst)
+	if v == nil {
+		return 0, false
+	}
+	slice, err := v.Bytes()
+	if err != nil {
+		return 0, false
+	}
+	n := copy(slice, src)
+	return int64(n), true
+}


### PR DESCRIPTION
## Description

Add `syscall/js.copyBytesToGo` and `syscall/js.copyBytesToJS` to support go1.13.x runtime.