### PR TITLE
Support non utxo transaction

### DIFF
--- a/cmd/cli/transfer.go
+++ b/cmd/cli/transfer.go
@@ -79,7 +79,7 @@ func NewTransferCommand(cli *Cli) *cobra.Command {
 
 func (t *TransferCommand) addFlags() {
 	t.cmd.Flags().StringVar(&t.to, "to", "", "common transfer transaction to whom")
-	t.cmd.Flags().StringVar(&t.amount, "amount", "", "transfer tokens")
+	t.cmd.Flags().StringVar(&t.amount, "amount", "0", "transfer tokens")
 	t.cmd.Flags().StringVar(&t.descfile, "desc", "", "desc file of tx, eg. contract or tdpos consensus")
 	t.cmd.Flags().StringVar(&t.fee, "fee", "0", "fee of one tx")
 	t.cmd.Flags().Int64Var(&t.frozenHeight, "frozen", 0, "frozen height of one tx")

--- a/consensus/tdpos/common.go
+++ b/consensus/tdpos/common.go
@@ -276,6 +276,9 @@ func (tp *TDpos) validateVote(desc *contract.TxDesc) (*voteInfo, error) {
 	if int64(len(voteInfo.candidates)) > tp.config.proposerNum {
 		return nil, errors.New("candidates nums should less than proposer nums")
 	}
+	if len(desc.Tx.TxInputs) <= 0 {
+		return nil, errors.New("when voting, TxInput should not be nil")
+	}
 	voteInfo.voter = string(desc.Tx.TxInputs[0].FromAddr)
 	tp.log.Trace("validateVote success", "voteInfo", voteInfo)
 	return voteInfo, nil
@@ -348,6 +351,9 @@ func (tp *TDpos) validateNominateCandidate(desc *contract.TxDesc) (*cons_base.Ca
 		return nil, "", err
 	}
 	// TODO: zq 多来源以后, 这里需要优化一下
+	if len(desc.Tx.TxInputs) <= 0 {
+		return nil, "", errors.New("validateNominateCandidate TxInput should not be nil")
+	}
 	fromAddr := string(desc.Tx.TxInputs[0].FromAddr)
 	canInfo := &cons_base.CandidateInfo{}
 
@@ -408,6 +414,9 @@ func (tp *TDpos) validateRevokeCandidate(desc *contract.TxDesc) (string, string,
 	candidate, ok := descNom.Args["candidate"].(string)
 	if !ok {
 		return "", "", "", errors.New("candidates should be string")
+	}
+	if len(descNom.Tx.TxInputs) <= 0 {
+		return "", "", "", errors.New("when validateRevokeCandidate, TxInputs should not be nil")
 	}
 	fromAddr := string(descNom.Tx.TxInputs[0].FromAddr)
 	return candidate, fromAddr, hex.EncodeToString(descNom.Tx.Txid), nil

--- a/consensus/tdpos/common_test.go
+++ b/consensus/tdpos/common_test.go
@@ -159,6 +159,11 @@ func TestValidateRevokeVote(t *testing.T) {
 	txReq.FromAddr = AliceAddress
 	txReq.FromPubkey = AlicePubkey
 	txReq.FromScrkey = AlicePrivateKey
+	txDataAccount := &pb.TxDataAccount{
+		Address: AliceAddress,
+		Amount:  "1",
+	}
+	txReq.Account = append(txReq.Account, txDataAccount)
 	txCons, errCons := utxoVM.GenerateTx(txReq)
 	if errCons != nil {
 		t.Error("GenerateTx error ", errCons.Error())
@@ -216,7 +221,7 @@ func TestValidateRevokeVote(t *testing.T) {
 
 	voteInfo, errValid := tdpos.validateVote(desc3)
 	if errValid != nil {
-		t.Error("validateVote error ", errValid.Error())
+		t.Error("validateVote error ", errValid.Error(), desc3)
 	} else {
 		t.Log("voteInfo ", voteInfo)
 	}

--- a/consensus/tdpos/rollback_test.go
+++ b/consensus/tdpos/rollback_test.go
@@ -33,7 +33,11 @@ func TestRollBackVote(t *testing.T) {
 		t.Error("roll back vote error ", rollBackVoteErr.Error())
 	}
 	// add cache
-	tdpos.candidateBallotsCache.LoadOrStore("D_candidate_ballots_f3prTg9itaZY6m48wXXikXdcxiByW7zgk", int64(1))
+	canBal := &candidateBallotsCacheValue{
+		ballots: int64(1),
+		isDel:   false,
+	}
+	tdpos.candidateBallotsCache.LoadOrStore("D_candidate_ballots_f3prTg9itaZY6m48wXXikXdcxiByW7zgk", canBal)
 	rollBackVoteErr = tdpos.rollbackVote(desc2, block)
 	if rollBackVoteErr != nil {
 		t.Error("roll back vote error ", rollBackVoteErr.Error())

--- a/consensus/tdpos/run_test.go
+++ b/consensus/tdpos/run_test.go
@@ -99,7 +99,13 @@ func makeTxWithDesc(strDesc []byte, U *utxo.UtxoVM, L *ledger.Ledger, t *testing
 	txReq.FromAddr = AliceAddress
 	txReq.FromPubkey = AlicePubkey
 	txReq.FromScrkey = AlicePrivateKey
+	txDataAccount := &pb.TxDataAccount{
+		Address: AliceAddress,
+		Amount:  "1",
+	}
+	txReq.Account = append(txReq.Account, txDataAccount)
 	txCons, errCons := U.GenerateTx(txReq)
+	//fmt.Println("----------------------transaction:", txCons)
 	if errCons != nil {
 		t.Error("GenerateTx error ", errCons.Error())
 	}
@@ -267,7 +273,7 @@ func TestRunRevokeCandidate(t *testing.T) {
 	}
 	revokeCandErr := tdpos.runRevokeCandidate(desc2, block)
 	if revokeCandErr != nil {
-		t.Error("runRevokeCandidate error ", revokeCandErr.Error())
+		t.Error("runRevokeCandidate error ", revokeCandErr.Error(), desc2)
 	}
 }
 

--- a/core/xchainmg_net.go
+++ b/core/xchainmg_net.go
@@ -134,12 +134,6 @@ func (xm *XChainMG) ProcessTx(in *pb.TxStatus) (*pb.CommonReply, bool, error) {
 		return out, false, err
 	}
 
-	if len(in.Tx.TxInputs) == 0 && !xm.Cfg.Utxo.NonUtxo {
-		out.Header.Error = pb.XChainErrorEnum_CONNECT_REFUSE // 拒绝
-		xm.Log.Warn("PostTx TxInputs can not be null while need utxo!", "logid", in.Header.Logid)
-		return out, false, nil
-	}
-
 	bc := xm.Get(in.Bcname)
 	if bc == nil {
 		out.Header.Error = pb.XChainErrorEnum_CONNECT_REFUSE // 拒绝

--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -639,6 +639,9 @@ func GenerateRootTx(js []byte) (*pb.Transaction, error) {
 //输入: 转账人地址、公钥、金额、是否需要锁定utxo
 //输出：选出的utxo、utxo keys、实际构成的金额(可能大于需要的金额)、错误码
 func (uv *UtxoVM) SelectUtxos(fromAddr string, fromPubKey string, totalNeed *big.Int, needLock, excludeUnconfirmed bool) ([]*pb.TxInput, [][]byte, *big.Int, error) {
+	if totalNeed.Cmp(big.NewInt(0)) == 0 {
+		return nil, nil, big.NewInt(0), nil
+	}
 	curLedgerHeight := uv.ledger.GetMeta().TrunkHeight
 	willLockKeys := make([][]byte, 0)
 	foundEnough := false


### PR DESCRIPTION
Non Utxo Transaction means that No TxInput and TxOuput is 0,
and you can store your data on the field of desc.

The approach of supporting non utxo transaction is that return 0 when invoking SelectUTXO
where totalNeed equals 0.


Fixes #577 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Regression Test
