### PR TITLE
contract: add contract call permission

### DIFF
--- a/contract/bridge/syscall_service.go
+++ b/contract/bridge/syscall_service.go
@@ -150,6 +150,11 @@ func (c *SyscallService) ContractCall(ctx context.Context, in *pb.ContractCallRe
 		return nil, errors.New("max contract call depth exceeds")
 	}
 
+	ok, err := nctx.Core.VerifyContractPermission(nctx.Initiator, nctx.AuthRequire, in.GetContract(), in.GetMethod())
+	if !ok || err != nil {
+		return nil, errors.New("verify contract permission failed")
+	}
+
 	vm, ok := c.vmm.GetVirtualMachine(in.GetModule())
 	if !ok {
 		return nil, errors.New("module not found")

--- a/contract/vm.go
+++ b/contract/vm.go
@@ -44,6 +44,7 @@ func ToPBContractResponse(resp *Response) *pb.ContractResponse {
 // ChainCore is the interface of chain service
 type ChainCore interface {
 	GetAccountAddresses(accountName string) ([]string, error)
+	VerifyContractPermission(initiator string, authRequire []string, contractName, methodName string) (bool, error)
 }
 
 // ContextConfig define the config of context

--- a/utxo/utxo.go
+++ b/utxo/utxo.go
@@ -180,6 +180,7 @@ type UtxoLockItem struct {
 
 type contractChainCore struct {
 	*acli.Manager // ACL manager for read/write acl table
+	*UtxoVM
 }
 
 func genUtxoKey(addr []byte, txid []byte, offset int32) string {
@@ -809,6 +810,7 @@ func (uv *UtxoVM) PreExec(req *pb.InvokeRPCRequest, hd *global.XContext) (*pb.In
 		ResourceLimits:           contract.MaxLimits,
 		Core: contractChainCore{
 			Manager: uv.aclMgr,
+			UtxoVM:  uv,
 		},
 		BCName: uv.bcname,
 	}


### PR DESCRIPTION
## Description

Different contracts can call each other through the call interface.
The caller needs to be authorized by the Contract Method.  

## Brief of your solution

Add ChainCore.VerifyContractPermission interface. 