### PR TITLE
fix contract transfer response can be changed

### DIFF
--- a/xmodel/env.go
+++ b/xmodel/env.go
@@ -1,15 +1,14 @@
 package xmodel
 
 import (
+	"errors"
 	"fmt"
-
 	"github.com/xuperchain/xuperunion/pb"
 	xmodel_pb "github.com/xuperchain/xuperunion/xmodel/pb"
 )
 
 // Env data structure for read/write sets environment
 type Env struct {
-	inputs     []*xmodel_pb.VersionedData
 	outputs    []*xmodel_pb.PureData
 	modelCache *XMCache
 }
@@ -35,12 +34,15 @@ func (s *XModel) PrepareEnv(tx *pb.Transaction) (*Env, error) {
 	for _, txOut := range tx.TxOutputsExt {
 		outputs = append(outputs, &xmodel_pb.PureData{Bucket: txOut.Bucket, Key: txOut.Key, Value: txOut.Value})
 	}
-	utxoInputs, err := ParseContractUtxoInputs(tx)
+	utxoInputs, utxoOutputs, err := ParseContractUtxo(tx)
 	if err != nil {
 		return nil, err
 	}
+	if ok := IsContractUtxoEffective(utxoInputs, utxoOutputs, tx); !ok {
+		s.logger.Warn("PrepareEnv CheckConUtxoEffective error")
+		return nil, errors.New("PrepareEnv CheckConUtxoEffective error")
+	}
 	env.modelCache = NewXModelCacheWithInputs(inputs, utxoInputs)
-	env.inputs = inputs
 	env.outputs = outputs
 	s.logger.Trace("PrepareEnv done!", "env", env)
 	return env, nil

--- a/xmodel/utxo_cache.go
+++ b/xmodel/utxo_cache.go
@@ -82,7 +82,6 @@ func (u *UtxoCache) Transfer(from, to string, amount *big.Int) error {
 			ToAddr: []byte(from),
 		})
 	}
-
 	return nil
 }
 

--- a/xmodel/xmodel_cache_test.go
+++ b/xmodel/xmodel_cache_test.go
@@ -233,3 +233,239 @@ func TestXModelCacheGet(t *testing.T) {
 		t.Error("Iterator error", keys2)
 	}
 }
+
+func TestIsContractUtxoEffective(t *testing.T) {
+	testCases := map[string]struct {
+		conTxInputs  []*pb.TxInput
+		conTxOutputs []*pb.TxOutput
+		tx           *pb.Transaction
+		res          bool
+	}{
+		"test check ok": {
+			conTxInputs: []*pb.TxInput{
+				&pb.TxInput{
+					RefTxid:   []byte("txInput1_RefTxid"),
+					RefOffset: 1,
+					FromAddr:  []byte("txInput1_FromAddr"),
+				},
+				&pb.TxInput{
+					RefTxid:   []byte("txInput2_RefTxid"),
+					RefOffset: 2,
+					FromAddr:  []byte("txInput2_FromAddr"),
+				},
+				&pb.TxInput{
+					RefTxid:   []byte("txInput3_RefTxid"),
+					RefOffset: 3,
+					FromAddr:  []byte("txInput3_FromAddr"),
+				},
+			},
+			conTxOutputs: []*pb.TxOutput{
+				&pb.TxOutput{
+					Amount: []byte("txOutput1_Amount"),
+					ToAddr: []byte("txOutput1_ToAddr"),
+				},
+				&pb.TxOutput{
+					Amount: []byte("txOutput2_Amount"),
+					ToAddr: []byte("txOutput2_ToAddr"),
+				},
+				&pb.TxOutput{
+					Amount: []byte("txOutput2_Amount"),
+					ToAddr: []byte("txOutput2_ToAddr"),
+				},
+			},
+			tx: &pb.Transaction{
+				TxInputs: []*pb.TxInput{
+					&pb.TxInput{
+						RefTxid:   []byte("txInput1_RefTxid"),
+						RefOffset: 1,
+						FromAddr:  []byte("txInput1_FromAddr"),
+					},
+					&pb.TxInput{
+						RefTxid:   []byte("txInput2_RefTxid"),
+						RefOffset: 2,
+						FromAddr:  []byte("txInput2_FromAddr"),
+					},
+					&pb.TxInput{
+						RefTxid:   []byte("txInput3_RefTxid"),
+						RefOffset: 3,
+						FromAddr:  []byte("txInput3_FromAddr"),
+					},
+					&pb.TxInput{
+						RefTxid:   []byte("txInput4_RefTxid"),
+						RefOffset: 4,
+						FromAddr:  []byte("txInput4_FromAddr"),
+					},
+				},
+				TxOutputs: []*pb.TxOutput{
+					&pb.TxOutput{
+						Amount: []byte("txOutput1_Amount"),
+						ToAddr: []byte("txOutput1_ToAddr"),
+					},
+					&pb.TxOutput{
+						Amount: []byte("txOutput2_Amount"),
+						ToAddr: []byte("txOutput2_ToAddr"),
+					},
+					&pb.TxOutput{
+						Amount: []byte("txOutput2_Amount"),
+						ToAddr: []byte("txOutput2_ToAddr"),
+					},
+					&pb.TxOutput{
+						Amount: []byte("txOutput3_Amount"),
+						ToAddr: []byte("txOutput3_ToAddr"),
+					},
+				},
+			},
+			res: true,
+		},
+		"test check failed1": {
+			conTxInputs: []*pb.TxInput{
+				&pb.TxInput{
+					RefTxid:   []byte("txInput1_RefTxid"),
+					RefOffset: 1,
+					FromAddr:  []byte("txInput1_FromAddr"),
+				},
+				&pb.TxInput{
+					RefTxid:   []byte("txInput2_RefTxid"),
+					RefOffset: 2,
+					FromAddr:  []byte("txInput2_FromAddr"),
+				},
+				&pb.TxInput{
+					RefTxid:   []byte("txInput3_RefTxid"),
+					RefOffset: 3,
+					FromAddr:  []byte("txInput3_FromAddr"),
+				},
+			},
+			conTxOutputs: []*pb.TxOutput{
+				&pb.TxOutput{
+					Amount: []byte("txOutput1_Amount"),
+					ToAddr: []byte("txOutput1_ToAddr"),
+				},
+				&pb.TxOutput{
+					Amount: []byte("txOutput2_Amount"),
+					ToAddr: []byte("txOutput2_ToAddr"),
+				},
+				&pb.TxOutput{
+					Amount: []byte("txOutput2_Amount"),
+					ToAddr: []byte("txOutput2_ToAddr"),
+				},
+			},
+			tx: &pb.Transaction{
+				TxInputs: []*pb.TxInput{
+					&pb.TxInput{
+						RefTxid:   []byte("txInput1_RefTxid"),
+						RefOffset: 1,
+						FromAddr:  []byte("txInput1_FromAddr"),
+					},
+					&pb.TxInput{
+						RefTxid:   []byte("txInput2_RefTxid"),
+						RefOffset: 2,
+						FromAddr:  []byte("txInput2_FromAddr"),
+					},
+					&pb.TxInput{
+						RefTxid:   []byte("txInput3_RefTxid"),
+						RefOffset: 3,
+						FromAddr:  []byte("txInput3_FromAddr"),
+					},
+					&pb.TxInput{
+						RefTxid:   []byte("txInput4_RefTxid"),
+						RefOffset: 4,
+						FromAddr:  []byte("txInput4_FromAddr"),
+					},
+				},
+				TxOutputs: []*pb.TxOutput{
+					&pb.TxOutput{
+						Amount: []byte("txOutput1_Amount"),
+						ToAddr: []byte("txOutput1_ToAddr"),
+					},
+					&pb.TxOutput{
+						Amount: []byte("txOutput2_Amount"),
+						ToAddr: []byte("txOutput2_ToAddr"),
+					},
+					&pb.TxOutput{
+						Amount: []byte("txOutput3_Amount"),
+						ToAddr: []byte("txOutput3_ToAddr"),
+					},
+				},
+			},
+			res: false,
+		},
+		"test check failed2": {
+			conTxInputs: []*pb.TxInput{
+				&pb.TxInput{
+					RefTxid:   []byte("txInput1_RefTxid"),
+					RefOffset: 1,
+					FromAddr:  []byte("txInput1_FromAddr"),
+				},
+				&pb.TxInput{
+					RefTxid:   []byte("txInput2_RefTxid"),
+					RefOffset: 2,
+					FromAddr:  []byte("txInput2_FromAddr"),
+				},
+				&pb.TxInput{
+					RefTxid:   []byte("txInput3_RefTxid"),
+					RefOffset: 3,
+					FromAddr:  []byte("txInput3_FromAddr"),
+				},
+			},
+			conTxOutputs: []*pb.TxOutput{
+				&pb.TxOutput{
+					Amount: []byte("txOutput1_Amount"),
+					ToAddr: []byte("txOutput1_ToAddr"),
+				},
+				&pb.TxOutput{
+					Amount: []byte("txOutput2_Amount"),
+					ToAddr: []byte("txOutput2_ToAddr"),
+				},
+				&pb.TxOutput{
+					Amount: []byte("txOutput4_Amount"),
+					ToAddr: []byte("txOutput4_ToAddr"),
+				},
+			},
+			tx: &pb.Transaction{
+				TxInputs: []*pb.TxInput{
+					&pb.TxInput{
+						RefTxid:   []byte("txInput1_RefTxid"),
+						RefOffset: 1,
+						FromAddr:  []byte("txInput1_FromAddr"),
+					},
+					&pb.TxInput{
+						RefTxid:   []byte("txInput2_RefTxid"),
+						RefOffset: 2,
+						FromAddr:  []byte("txInput2_FromAddr"),
+					},
+					&pb.TxInput{
+						RefTxid:   []byte("txInput3_RefTxid"),
+						RefOffset: 3,
+						FromAddr:  []byte("txInput3_FromAddr"),
+					},
+					&pb.TxInput{
+						RefTxid:   []byte("txInput4_RefTxid"),
+						RefOffset: 4,
+						FromAddr:  []byte("txInput4_FromAddr"),
+					},
+				},
+				TxOutputs: []*pb.TxOutput{
+					&pb.TxOutput{
+						Amount: []byte("txOutput1_Amount"),
+						ToAddr: []byte("txOutput1_ToAddr"),
+					},
+					&pb.TxOutput{
+						Amount: []byte("txOutput2_Amount"),
+						ToAddr: []byte("txOutput2_ToAddr"),
+					},
+					&pb.TxOutput{
+						Amount: []byte("txOutput3_Amount"),
+						ToAddr: []byte("txOutput3_ToAddr"),
+					},
+				},
+			},
+			res: false,
+		},
+	}
+	for k, v := range testCases {
+		res := IsContractUtxoEffective(v.conTxInputs, v.conTxOutputs, v.tx)
+		if res != v.res {
+			t.Error("TestIsConUtxoEffective failed case=", k, "expect=", v.res, "actual=", res)
+		}
+	}
+}


### PR DESCRIPTION
## Description

What is the purpose of the change?
Now, manual change of the contract transfer response can still be executed successfully.
It's need to be fixed. 

Fixes #591 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution
The contract transfer utxo result  must in `tx.Inputs`  and  `tx.Outpus`.
