### PR TITLE
fix amount of issue and transfer be negative

### DIFF
--- a/contractsdk/cpp/XRC/xrc01/src/main/xrc01_e1.cc
+++ b/contractsdk/cpp/XRC/xrc01/src/main/xrc01_e1.cc
@@ -18,13 +18,16 @@ bool safe_stoull(const std::string* in, uint64_t* out) {
     if (!in) {
         return false;
     }
-    if (in->substr(0,1) == "-") {
+    size_t first = in->find_first_not_of(' ');
+    size_t last = in->find_last_not_of(' ');
+    std::string in_trimed = in->substr(first, (last-first+1));
+    if (in_trimed.substr(0,1) == "-") {
         printf("issue error, param amount can not be negative \n");
         return false;
     }
     std::string::size_type sz = 0;
-    (*out) = std::stoull((*in), &sz);
-    if (sz != in->size()) {
+    (*out) = std::stoull((in_trimed), &sz);
+    if (sz != in_trimed.size()) {
         return false;
     }
     return true;

--- a/contractsdk/cpp/XRC/xrc01/src/main/xrc01_e1.cc
+++ b/contractsdk/cpp/XRC/xrc01/src/main/xrc01_e1.cc
@@ -18,16 +18,14 @@ bool safe_stoull(const std::string* in, uint64_t* out) {
     if (!in) {
         return false;
     }
-    size_t first = in->find_first_not_of(' ');
-    size_t last = in->find_last_not_of(' ');
-    std::string in_trimed = in->substr(first, (last-first+1));
-    if (in_trimed.substr(0,1) == "-") {
-        printf("issue error, param amount can not be negative \n");
-        return false;
+    for (int i = 0; i < in->size(); i++) {
+        if (in[i] < "0" || in[i] > "9") {
+            return false;
+        }    
     }
     std::string::size_type sz = 0;
-    (*out) = std::stoull((in_trimed), &sz);
-    if (sz != in_trimed.size()) {
+    (*out) = std::stoull((*in), &sz);
+    if (sz != in->size()) {
         return false;
     }
     return true;

--- a/contractsdk/cpp/XRC/xrc01/src/main/xrc01_e1.cc
+++ b/contractsdk/cpp/XRC/xrc01/src/main/xrc01_e1.cc
@@ -18,6 +18,10 @@ bool safe_stoull(const std::string* in, uint64_t* out) {
     if (!in) {
         return false;
     }
+    if (in->substr(0,1) == "-") {
+        printf("issue error, param amount can not be negative \n");
+        return false;
+    }
     std::string::size_type sz = 0;
     (*out) = std::stoull((*in), &sz);
     if (sz != in->size()) {


### PR DESCRIPTION
## Description

What is the purpose of the change?
Now the amount of example `xrc01_e1` of `XRC01` can be negative and will be convert to  the Maximum of `uint64`. 

This pull request used to check whether parameters be negative.

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)