### PR TITLE
bugfix: unlock useless key when merging utxo

### DIFF
--- a/utxo/merge_utxo.go
+++ b/utxo/merge_utxo.go
@@ -86,7 +86,9 @@ func (uv *UtxoVM) SelectUtxosBySize(fromAddr string, fromPubKey string, needLock
 		if txInputSize.Cmp(maxTxSize) == 1 {
 			txInputs = txInputs[:len(txInputs)-1]
 			amount.Sub(amount, utxoItem.Amount)
-			uv.unlockKey(key)
+			if needLock {
+				uv.unlockKey(key)
+			}
 			break
 		} else {
 			continue

--- a/utxo/merge_utxo.go
+++ b/utxo/merge_utxo.go
@@ -86,6 +86,7 @@ func (uv *UtxoVM) SelectUtxosBySize(fromAddr string, fromPubKey string, needLock
 		if txInputSize.Cmp(maxTxSize) == 1 {
 			txInputs = txInputs[:len(txInputs)-1]
 			amount.Sub(amount, utxoItem.Amount)
+			uv.unlockKey(key)
 			break
 		} else {
 			continue


### PR DESCRIPTION
## Description

What is the purpose of the change?
When the capacity is over, the key has been locked should be unlocked again.

Fixes # (issue)

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)


## Brief of your solution

When the capacity is over, the key has been locked should be unlocked again.

## How Has This Been Tested?

Regression Test
