### PR TITLE
fix amount of issue and transfer be negative

### DIFF
--- a/contractsdk/cpp/XRC/xrc01/src/main/xrc01_e1.cc
+++ b/contractsdk/cpp/XRC/xrc01/src/main/xrc01_e1.cc
@@ -18,9 +18,7 @@ bool safe_stoull(const std::string in, uint64_t* out) {
     if (in == "") {
         return false;
     }
-    printf("safe_stoull in=%s in.size=%lu \n", in.c_str(), in.size());
     for (int i = 0; i < in.size(); i++) {
-        printf("safe_stoull i=%d, in[i]= %hhd \n", i, in[i]);
         if (in[i] < '0' || in[i] > '9') {
             return false;
         }    

--- a/contractsdk/cpp/XRC/xrc01/src/main/xrc01_e1.cc
+++ b/contractsdk/cpp/XRC/xrc01/src/main/xrc01_e1.cc
@@ -14,18 +14,20 @@ bool str2bool(const std::string var, bool& var_bool) {
     return false;
 }
 
-bool safe_stoull(const std::string* in, uint64_t* out) {
-    if (!in) {
+bool safe_stoull(const std::string in, uint64_t* out) {
+    if (in == "") {
         return false;
     }
-    for (int i = 0; i < in->size(); i++) {
-        if (in[i] < "0" || in[i] > "9") {
+    printf("safe_stoull in=%s in.size=%lu \n", in.c_str(), in.size());
+    for (int i = 0; i < in.size(); i++) {
+        printf("safe_stoull i=%d, in[i]= %hhd \n", i, in[i]);
+        if (in[i] < '0' || in[i] > '9') {
             return false;
         }    
     }
     std::string::size_type sz = 0;
-    (*out) = std::stoull((*in), &sz);
-    if (sz != in->size()) {
+    (*out) = std::stoull(in, &sz);
+    if (sz != in.size()) {
         return false;
     }
     return true;
@@ -58,13 +60,13 @@ DEFINE_METHOD(XRC01_E1, issue) {
     }
 
     uint64_t id;
-    if (!safe_stoull(&(ctx->arg("id")), &id)) {
+    if (!safe_stoull(ctx->arg("id"), &id)) {
         ctx->error("issue error, param id error");
         return;
     }
     const std::string& name = ctx->arg("name");
     uint64_t supply;
-    if (!safe_stoull(&(ctx->arg("supply")), &supply)) {
+    if (!safe_stoull(ctx->arg("supply"), &supply)) {
         ctx->error("issue error, param supply error");
         return;
     }
@@ -95,13 +97,13 @@ DEFINE_METHOD(XRC01_E1, authorization) {
     XRC01 xrc01(ctx);
     const std::string& to = ctx->arg("to");
     uint64_t token_id;
-    if (!safe_stoull(&(ctx->arg("token_id")), &token_id)) {
+    if (!safe_stoull(ctx->arg("token_id"), &token_id)) {
         ctx->error("authorization error, param token_id error");
         return;
     }
 
     uint64_t amount;
-    if (!safe_stoull(&(ctx->arg("amount")), &amount)) {
+    if (!safe_stoull(ctx->arg("amount"), &amount)) {
         ctx->error("authorization error, param amount error");
         return;
     }
@@ -119,13 +121,13 @@ DEFINE_METHOD(XRC01_E1, withdraw_authorization) {
 
     const std::string& from = ctx->arg("from");
     uint64_t token_id;
-    if (!safe_stoull(&(ctx->arg("token_id")), &token_id)) {
+    if (!safe_stoull(ctx->arg("token_id"), &token_id)) {
         ctx->error("withdraw_authorization error, param token_id error");
         return;
     }
 
     uint64_t amount;
-    if (!safe_stoull(&(ctx->arg("amount")), &amount)) {
+    if (!safe_stoull(ctx->arg("amount"), &amount)) {
         ctx->error("withdraw_authorization error, param amount error");
         return;
     }
@@ -144,13 +146,13 @@ DEFINE_METHOD(XRC01_E1, transfer) {
 
     const std::string& to = ctx->arg("to");
     uint64_t token_id;
-    if (!safe_stoull(&(ctx->arg("token_id")), &token_id)) {
+    if (!safe_stoull(ctx->arg("token_id"), &token_id)) {
         ctx->error("transfer error, param token_id error");
         return;
     }
 
     uint64_t amount;
-    if (!safe_stoull(&(ctx->arg("amount")), &amount)) {
+    if (!safe_stoull(ctx->arg("amount"), &amount)) {
         ctx->error("transfer error, param amount error");
         return;
     }
@@ -170,13 +172,13 @@ DEFINE_METHOD(XRC01_E1, authorize_transfer) {
     const std::string& from = ctx->arg("from");
     const std::string& to = ctx->arg("to");
     uint64_t token_id;
-    if (!safe_stoull(&(ctx->arg("token_id")), &token_id)) {
+    if (!safe_stoull(ctx->arg("token_id"), &token_id)) {
         ctx->error("authorize_transfer error, param token_id error");
         return;
     }
 
     uint64_t amount;
-    if (!safe_stoull(&(ctx->arg("amount")), &amount)) {
+    if (!safe_stoull(ctx->arg("amount"), &amount)) {
         ctx->error("authorize_transfer error, param amount error");
         return;
     }
@@ -195,7 +197,7 @@ DEFINE_METHOD(XRC01_E1, get_balance) {
 
     const std::string& account = ctx->arg("account");
     uint64_t token_id;
-    if (!safe_stoull(&(ctx->arg("token_id")), &token_id)) {
+    if (!safe_stoull(ctx->arg("token_id"), &token_id)) {
         ctx->error("get_balance error, param token_id error");
         return;
     }
@@ -215,7 +217,7 @@ DEFINE_METHOD(XRC01_E1, get_authorized) {
 
     const std::string& account = ctx->arg("account");
     uint64_t token_id;
-    if (!safe_stoull(&(ctx->arg("token_id")), &token_id)) {
+    if (!safe_stoull(ctx->arg("token_id"), &token_id)) {
         ctx->error("get_authorized error, param token_id error");
         return;
     }
@@ -234,7 +236,7 @@ DEFINE_METHOD(XRC01_E1, get_owner_of) {
     XRC01 xrc01(ctx);
 
     uint64_t token_id;
-    if (!safe_stoull(&(ctx->arg("token_id")), &token_id)) {
+    if (!safe_stoull(ctx->arg("token_id"), &token_id)) {
         ctx->error("get_owner_of error, param token_id error");
         return;
     }
@@ -255,7 +257,7 @@ DEFINE_METHOD(XRC01_E1, get_authorize_infos) {
 
     const std::string& account = ctx->arg("account");
     uint64_t token_id;
-    if (!safe_stoull(&(ctx->arg("token_id")), &token_id)) {
+    if (!safe_stoull(ctx->arg("token_id"), &token_id)) {
         ctx->error("get_authorize_infos error, param token_id error");
         return;
     }
@@ -284,7 +286,7 @@ DEFINE_METHOD(XRC01_E1, get_authorized_infos) {
 
     const std::string& account = ctx->arg("account");
     uint64_t token_id;
-    if (!safe_stoull(&(ctx->arg("token_id")), &token_id)) {
+    if (!safe_stoull(ctx->arg("token_id"), &token_id)) {
         ctx->error("get_authorized_infos error, param token_id error");
         return;
     }


### PR DESCRIPTION
## Description

What is the purpose of the change?
Now the amount of example `xrc01_e1` of `XRC01` can be negative and will be convert to  the Maximum of `uint64`. 

This pull request used to check whether parameters be negative.

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)