### PR TITLE
Fix Bug#617: Transfer to contract failed when fee is not greater than amount

### DIFF
--- a/cmd/cli/comm_trans.go
+++ b/cmd/cli/comm_trans.go
@@ -282,7 +282,7 @@ func (c *CommTrans) GenTxOutputs(gasUsed int64) ([]*pb.TxOutput, *big.Int, error
 
 	// 组装txOutputs
 	bigZero := big.NewInt(0)
-	totalNeed := bigZero
+	totalNeed := big.NewInt(0)
 	txOutputs := []*pb.TxOutput{}
 	for _, acc := range accounts {
 		amount, ok := big.NewInt(0).SetString(acc.Amount, 10)


### PR DESCRIPTION
## Description

Fix #617  Transfer to contract failed when fee is not greater than amount.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution

Copy a big integer instance to another variable using ":=" is a reference copy. So after `totalNeed` is changed, the `bigZero` is also changed.

Create dependent `bigZero` instance.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
